### PR TITLE
Neaten the history listing code

### DIFF
--- a/src/command/history.rs
+++ b/src/command/history.rs
@@ -34,6 +34,12 @@ pub enum Cmd {
     },
 }
 
+fn print_list(h: &Vec<History>) {
+    for i in h {
+        println!("{}", i.command);
+    }
+}
+
 impl Cmd {
     pub fn run(&self, db: &mut Sqlite) -> Result<()> {
         match self {
@@ -68,7 +74,12 @@ impl Cmd {
                 Ok(())
             }
 
-            Self::List { distinct } => db.list(*distinct),
+            Self::List { .. } => {
+                let history = db.list()?;
+                print_list(&history);
+
+                Ok(())
+            }
         }
     }
 }


### PR DESCRIPTION
I'd like to reduce the amount of SQL in the database code. Make it as
generic as possible, and later on perhaps expose a generic "execute"
function.

This function can be used by analysis commands, and the SQL can live
there - rather than database.rs being a huge bag of SQL.