### PR TITLE
Allow using Ctrl-c to exit

### DIFF
--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -153,7 +153,7 @@ async fn key_handler(
     app: &mut State,
 ) -> Option<String> {
     match input {
-        Key::Esc => return Some(String::from("")),
+        Key::Esc | Key::Ctrl('c') => return Some(String::from("")),
         Key::Char('\n') => {
             let i = app.results_state.selected().unwrap_or(0);
 


### PR DESCRIPTION
Resolves #52

I would like a properly configurable approach to keybinding, but for now I can see how it might be jarring for ctrl-c to be a noop