### PR TITLE
Generic Importer Trait

### DIFF
--- a/atuin-client/src/import/bash.rs
+++ b/atuin-client/src/import/bash.rs
@@ -1,9 +1,8 @@
+use std::{fs::File, path::Path};
 use std::{
-    env,
     io::{BufRead, BufReader},
     path::PathBuf,
 };
-use std::{fs::File, path::Path};
 
 use directories::UserDirs;
 use eyre::{eyre, Result};
@@ -20,20 +19,9 @@ pub struct Bash {
 }
 
 impl Importer for Bash {
+    const NAME: &'static str = "bash";
+
     fn histpath() -> Result<PathBuf> {
-        if let Ok(p) = env::var("HISTFILE") {
-            let histpath = PathBuf::from(p);
-
-            if !histpath.exists() {
-                return Err(eyre!(
-                    "Could not find history file {:?}. try updating $HISTFILE",
-                    histpath
-                ));
-            }
-
-            return Ok(histpath);
-        }
-
         let user_dirs = UserDirs::new().unwrap();
         let home_dir = user_dirs.home_dir();
 

--- a/atuin-client/src/import/bash.rs
+++ b/atuin-client/src/import/bash.rs
@@ -53,7 +53,7 @@ impl Importer for Bash {
         })
     }
 
-    fn len(&self) -> u64 {
+    fn count(&self) -> u64 {
         self.loc
     }
 }

--- a/atuin-client/src/import/bash.rs
+++ b/atuin-client/src/import/bash.rs
@@ -1,11 +1,7 @@
 use std::{
     fs::File,
-    io::{Read, Seek},
-    path::Path,
-};
-use std::{
-    io::{BufRead, BufReader},
-    path::PathBuf,
+    io::{BufRead, BufReader, Read, Seek},
+    path::{Path, PathBuf},
 };
 
 use directories::UserDirs;

--- a/atuin-client/src/import/mod.rs
+++ b/atuin-client/src/import/mod.rs
@@ -23,5 +23,5 @@ fn count_lines(buf: &mut BufReader<File>) -> Result<usize> {
 pub trait Importer: IntoIterator<Item = Result<History>> + Sized {
     fn histpath() -> Result<PathBuf>;
     fn parse(path: impl AsRef<Path>) -> Result<Self>;
-    fn len(&self) -> u64;
+    fn count(&self) -> u64;
 }

--- a/atuin-client/src/import/mod.rs
+++ b/atuin-client/src/import/mod.rs
@@ -21,6 +21,7 @@ fn count_lines(buf: &mut BufReader<File>) -> Result<usize> {
 }
 
 pub trait Importer: IntoIterator<Item = Result<History>> + Sized {
+    const NAME: &'static str;
     fn histpath() -> Result<PathBuf>;
     fn parse(path: impl AsRef<Path>) -> Result<Self>;
     fn count(&self) -> u64;

--- a/atuin-client/src/import/mod.rs
+++ b/atuin-client/src/import/mod.rs
@@ -1,8 +1,5 @@
-use std::io::{BufRead, BufReader, Seek, SeekFrom};
-use std::{
-    fs::File,
-    path::{Path, PathBuf},
-};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
 
 use eyre::Result;
 
@@ -13,7 +10,7 @@ pub mod resh;
 pub mod zsh;
 
 // this could probably be sped up
-fn count_lines(buf: &mut BufReader<File>) -> Result<usize> {
+fn count_lines(buf: &mut BufReader<impl Read + Seek>) -> Result<usize> {
     let lines = buf.lines().count();
     buf.seek(SeekFrom::Start(0))?;
 

--- a/atuin-client/src/import/mod.rs
+++ b/atuin-client/src/import/mod.rs
@@ -1,7 +1,12 @@
-use std::fs::File;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
 
 use eyre::Result;
+
+use crate::history::History;
 
 pub mod bash;
 pub mod resh;
@@ -13,4 +18,10 @@ fn count_lines(buf: &mut BufReader<File>) -> Result<usize> {
     buf.seek(SeekFrom::Start(0))?;
 
     Ok(lines)
+}
+
+pub trait Importer: IntoIterator<Item = Result<History>> + Sized {
+    fn histpath() -> Result<PathBuf>;
+    fn parse(path: impl AsRef<Path>) -> Result<Self>;
+    fn len(&self) -> u64;
 }

--- a/atuin-client/src/import/mod.rs
+++ b/atuin-client/src/import/mod.rs
@@ -24,5 +24,4 @@ pub trait Importer: IntoIterator<Item = Result<History>> + Sized {
     const NAME: &'static str;
     fn histpath() -> Result<PathBuf>;
     fn parse(path: impl AsRef<Path>) -> Result<Self>;
-    fn count(&self) -> u64;
 }

--- a/atuin-client/src/import/resh.rs
+++ b/atuin-client/src/import/resh.rs
@@ -132,7 +132,7 @@ impl Importer for Resh {
         })
     }
 
-    fn len(&self) -> u64 {
+    fn count(&self) -> u64 {
         self.loc
     }
 }

--- a/atuin-client/src/import/resh.rs
+++ b/atuin-client/src/import/resh.rs
@@ -148,7 +148,12 @@ impl Iterator for Resh {
 
         let entry = match serde_json::from_str::<ReshEntry>(&self.strbuf) {
             Ok(e) => e,
-            Err(e) => return Some(Err(eyre!("Invalid entry found in resh_history file: {}", e))),
+            Err(e) => {
+                return Some(Err(eyre!(
+                    "Invalid entry found in resh_history file: {}",
+                    e
+                )))
+            }
         };
 
         #[allow(clippy::cast_possible_truncation)]

--- a/atuin-client/src/import/resh.rs
+++ b/atuin-client/src/import/resh.rs
@@ -112,6 +112,8 @@ pub struct Resh {
 }
 
 impl Importer for Resh {
+    const NAME: &'static str = "resh";
+
     fn histpath() -> Result<PathBuf> {
         let user_dirs = UserDirs::new().unwrap();
         let home_dir = user_dirs.home_dir();

--- a/atuin-client/src/import/resh.rs
+++ b/atuin-client/src/import/resh.rs
@@ -107,7 +107,7 @@ pub struct ReshEntry {
 pub struct Resh {
     file: BufReader<File>,
     strbuf: String,
-    loc: u64,
+    loc: usize,
     counter: i64,
 }
 
@@ -129,13 +129,9 @@ impl Importer for Resh {
         Ok(Self {
             file: buf,
             strbuf: String::new(),
-            loc: loc as u64,
+            loc,
             counter: 0,
         })
-    }
-
-    fn count(&self) -> u64 {
-        self.loc
     }
 }
 
@@ -181,5 +177,9 @@ impl Iterator for Resh {
             session: uuid_v4(),
             hostname: entry.host,
         }))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.loc, Some(self.loc))
     }
 }

--- a/atuin-client/src/import/resh.rs
+++ b/atuin-client/src/import/resh.rs
@@ -14,90 +14,56 @@ use super::{count_lines, Importer};
 use crate::history::History;
 
 #[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct ReshEntry {
-    #[serde(rename = "cmdLine")]
     pub cmd_line: String,
-    #[serde(rename = "exitCode")]
     pub exit_code: i64,
     pub shell: String,
     pub uname: String,
-    #[serde(rename = "sessionId")]
     pub session_id: String,
     pub home: String,
     pub lang: String,
-    #[serde(rename = "lcAll")]
     pub lc_all: String,
     pub login: String,
     pub pwd: String,
-    #[serde(rename = "pwdAfter")]
     pub pwd_after: String,
-    #[serde(rename = "shellEnv")]
     pub shell_env: String,
     pub term: String,
-    #[serde(rename = "realPwd")]
     pub real_pwd: String,
-    #[serde(rename = "realPwdAfter")]
     pub real_pwd_after: String,
     pub pid: i64,
-    #[serde(rename = "sessionPid")]
     pub session_pid: i64,
     pub host: String,
     pub hosttype: String,
     pub ostype: String,
     pub machtype: String,
     pub shlvl: i64,
-    #[serde(rename = "timezoneBefore")]
     pub timezone_before: String,
-    #[serde(rename = "timezoneAfter")]
     pub timezone_after: String,
-    #[serde(rename = "realtimeBefore")]
     pub realtime_before: f64,
-    #[serde(rename = "realtimeAfter")]
     pub realtime_after: f64,
-    #[serde(rename = "realtimeBeforeLocal")]
     pub realtime_before_local: f64,
-    #[serde(rename = "realtimeAfterLocal")]
     pub realtime_after_local: f64,
-    #[serde(rename = "realtimeDuration")]
     pub realtime_duration: f64,
-    #[serde(rename = "realtimeSinceSessionStart")]
     pub realtime_since_session_start: f64,
-    #[serde(rename = "realtimeSinceBoot")]
     pub realtime_since_boot: f64,
-    #[serde(rename = "gitDir")]
     pub git_dir: String,
-    #[serde(rename = "gitRealDir")]
     pub git_real_dir: String,
-    #[serde(rename = "gitOriginRemote")]
     pub git_origin_remote: String,
-    #[serde(rename = "gitDirAfter")]
     pub git_dir_after: String,
-    #[serde(rename = "gitRealDirAfter")]
     pub git_real_dir_after: String,
-    #[serde(rename = "gitOriginRemoteAfter")]
     pub git_origin_remote_after: String,
-    #[serde(rename = "machineId")]
     pub machine_id: String,
-    #[serde(rename = "osReleaseId")]
     pub os_release_id: String,
-    #[serde(rename = "osReleaseVersionId")]
     pub os_release_version_id: String,
-    #[serde(rename = "osReleaseIdLike")]
     pub os_release_id_like: String,
-    #[serde(rename = "osReleaseName")]
     pub os_release_name: String,
-    #[serde(rename = "osReleasePrettyName")]
     pub os_release_pretty_name: String,
-    #[serde(rename = "reshUuid")]
     pub resh_uuid: String,
-    #[serde(rename = "reshVersion")]
     pub resh_version: String,
-    #[serde(rename = "reshRevision")]
     pub resh_revision: String,
-    #[serde(rename = "partsMerged")]
     pub parts_merged: bool,
     pub recalled: bool,
-    #[serde(rename = "recallLastCmdLine")]
     pub recall_last_cmd_line: String,
     pub cols: String,
     pub lines: String,

--- a/atuin-client/src/import/zsh.rs
+++ b/atuin-client/src/import/zsh.rs
@@ -43,7 +43,7 @@ impl Importer for Zsh {
                         break Ok(histpath);
                     }
                 }
-                None => break Err(eyre!("Could not find history file. try setting $HISTFILE")),
+                None => break Err(eyre!("Could not find history file. Try setting $HISTFILE")),
             }
         }
     }

--- a/atuin-client/src/import/zsh.rs
+++ b/atuin-client/src/import/zsh.rs
@@ -1,12 +1,11 @@
 // import old shell history!
 // automatically hoover up all that we can find
 
+use std::{fs::File, path::Path};
 use std::{
-    env,
     io::{BufRead, BufReader},
     path::PathBuf,
 };
-use std::{fs::File, path::Path};
 
 use chrono::prelude::*;
 use chrono::Utc;
@@ -26,24 +25,12 @@ pub struct Zsh {
 }
 
 impl Importer for Zsh {
+    const NAME: &'static str = "zsh";
+
     fn histpath() -> Result<PathBuf> {
         // oh-my-zsh sets HISTFILE=~/.zhistory
         // zsh has no default value for this var, but uses ~/.zhistory.
         // we could maybe be smarter about this in the future :)
-
-        if let Ok(p) = env::var("HISTFILE") {
-            let histpath = PathBuf::from(p);
-
-            if !histpath.exists() {
-                return Err(eyre!(
-                    "Could not find history file {:?}. try updating $HISTFILE",
-                    histpath
-                ));
-            }
-
-            return Ok(histpath);
-        }
-
         let user_dirs = UserDirs::new().unwrap();
         let home_dir = user_dirs.home_dir();
 

--- a/atuin-client/src/import/zsh.rs
+++ b/atuin-client/src/import/zsh.rs
@@ -3,12 +3,8 @@
 
 use std::{
     fs::File,
-    io::{Read, Seek},
-    path::Path,
-};
-use std::{
-    io::{BufRead, BufReader},
-    path::PathBuf,
+    io::{BufRead, BufReader, Read, Seek},
+    path::{Path, PathBuf},
 };
 
 use chrono::prelude::*;

--- a/atuin-client/src/import/zsh.rs
+++ b/atuin-client/src/import/zsh.rs
@@ -74,7 +74,7 @@ impl Importer for Zsh {
         })
     }
 
-    fn len(&self) -> u64 {
+    fn count(&self) -> u64 {
         self.loc
     }
 }

--- a/src/command/import.rs
+++ b/src/command/import.rs
@@ -102,10 +102,15 @@ where
 
     let contents = I::parse(histpath)?;
 
-    let progress = ProgressBar::new(contents.count());
+    let iter = contents.into_iter();
+    let progress = if let (_, Some(upper_bound)) = iter.size_hint() {
+        ProgressBar::new(upper_bound as u64)
+    } else {
+        ProgressBar::new_spinner()
+    };
 
     let mut buf = Vec::<History>::with_capacity(buf_size);
-    let mut iter = progress.wrap_iter(contents.into_iter());
+    let mut iter = progress.wrap_iter(iter);
     loop {
         // clear buffer
         buf.clear();

--- a/src/command/import.rs
+++ b/src/command/import.rs
@@ -81,7 +81,7 @@ where
 
         if !histpath.is_file() {
             return Err(eyre!(
-                "Could not find history file {:?}. Try updating $HISTFILE",
+                "Could not find history file {:?}. Try setting $HISTFILE",
                 histpath
             ));
         }

--- a/src/command/import.rs
+++ b/src/command/import.rs
@@ -1,15 +1,12 @@
 use std::env;
-use std::path::PathBuf;
 
-use atuin_common::utils::uuid_v4;
-use chrono::{TimeZone, Utc};
-use directories::UserDirs;
-use eyre::{eyre, Result};
+use eyre::Result;
+use itertools::Itertools;
 use structopt::StructOpt;
 
-use atuin_client::history::History;
+use atuin_client::{history::History, import::resh::Resh};
 use atuin_client::import::{bash::Bash, zsh::Zsh};
-use atuin_client::{database::Database, import::resh::ReshEntry};
+use atuin_client::{database::Database, import::Importer};
 use indicatif::ProgressBar;
 
 #[derive(StructOpt)]
@@ -49,216 +46,47 @@ impl Cmd {
         println!("======================");
         println!("Importing history...");
 
+        const BATCH_SIZE: usize = 100;
+
         match self {
             Self::Auto => {
                 let shell = env::var("SHELL").unwrap_or_else(|_| String::from("NO_SHELL"));
 
                 if shell.ends_with("/zsh") {
                     println!("Detected ZSH");
-                    import_zsh(db).await
+                    import::<Zsh, _>(db, BATCH_SIZE).await
                 } else {
                     println!("cannot import {} history", shell);
                     Ok(())
                 }
             }
 
-            Self::Zsh => import_zsh(db).await,
-            Self::Bash => import_bash(db).await,
-            Self::Resh => import_resh(db).await,
+            Self::Zsh => import::<Zsh, _>(db, BATCH_SIZE).await,
+            Self::Bash => import::<Bash, _>(db, BATCH_SIZE).await,
+            Self::Resh => import::<Resh, _>(db, BATCH_SIZE).await,
         }
     }
 }
 
-async fn import_resh(db: &mut (impl Database + Send + Sync)) -> Result<()> {
-    let histpath = std::path::Path::new(std::env::var("HOME")?.as_str()).join(".resh_history.json");
+async fn import<I: Importer, DB: Database + Send + Sync>(
+    db: &mut DB,
+    buf_size: usize,
+) -> Result<()> {
+    let histpath = I::histpath()?;
+    let contents = I::parse(histpath)?;
 
-    println!("Parsing .resh_history.json...");
-    #[allow(clippy::filter_map)]
-    let history = std::fs::read_to_string(histpath)?
-        .split('\n')
-        .map(str::trim)
-        .map(|x| serde_json::from_str::<ReshEntry>(x))
-        .filter_map(|x| match x {
-            Ok(x) => Some(x),
-            Err(e) => {
-                if e.is_eof() {
-                    None
-                } else {
-                    warn!("Invalid entry found in resh_history file: {}", e);
-                    None
-                }
-            }
-        })
-        .map(|x| {
-            #[allow(clippy::cast_possible_truncation)]
-            #[allow(clippy::cast_sign_loss)]
-            let timestamp = {
-                let secs = x.realtime_before.floor() as i64;
-                let nanosecs = (x.realtime_before.fract() * 1_000_000_000_f64).round() as u32;
-                Utc.timestamp(secs, nanosecs)
-            };
-            #[allow(clippy::cast_possible_truncation)]
-            #[allow(clippy::cast_sign_loss)]
-            let duration = {
-                let secs = x.realtime_after.floor() as i64;
-                let nanosecs = (x.realtime_after.fract() * 1_000_000_000_f64).round() as u32;
-                let difference = Utc.timestamp(secs, nanosecs) - timestamp;
-                difference.num_nanoseconds().unwrap_or(0)
-            };
+    let progress = ProgressBar::new(contents.len());
 
-            History {
-                id: uuid_v4(),
-                timestamp,
-                duration,
-                exit: x.exit_code,
-                command: x.cmd_line,
-                cwd: x.pwd,
-                session: uuid_v4(),
-                hostname: x.host,
-            }
-        })
-        .collect::<Vec<_>>();
-    println!("Updating database...");
-
-    let progress = ProgressBar::new(history.len() as u64);
-
-    let buf_size = 100;
-    let mut buf = Vec::<_>::with_capacity(buf_size);
-
-    for i in history {
-        buf.push(i);
-
-        if buf.len() == buf_size {
-            db.save_bulk(&buf).await?;
-            progress.inc(buf.len() as u64);
-
-            buf.clear();
-        }
-    }
-
-    if !buf.is_empty() {
-        db.save_bulk(&buf).await?;
-        progress.inc(buf.len() as u64);
-    }
-    Ok(())
-}
-
-async fn import_zsh(db: &mut (impl Database + Send + Sync)) -> Result<()> {
-    // oh-my-zsh sets HISTFILE=~/.zhistory
-    // zsh has no default value for this var, but uses ~/.zhistory.
-    // we could maybe be smarter about this in the future :)
-
-    let histpath = env::var("HISTFILE");
-
-    let histpath = if let Ok(p) = histpath {
-        let histpath = PathBuf::from(p);
-
-        if !histpath.exists() {
-            return Err(eyre!(
-                "Could not find history file {:?}. try updating $HISTFILE",
-                histpath
-            ));
-        }
-
-        histpath
-    } else {
-        let user_dirs = UserDirs::new().unwrap();
-        let home_dir = user_dirs.home_dir();
-
-        let mut candidates = [".zhistory", ".zsh_history"].iter();
-        loop {
-            match candidates.next() {
-                Some(candidate) => {
-                    let histpath = home_dir.join(candidate);
-                    if histpath.exists() {
-                        break histpath;
-                    }
-                }
-                None => return Err(eyre!("Could not find history file. try setting $HISTFILE")),
-            }
-        }
-    };
-
-    let zsh = Zsh::new(histpath)?;
-
-    let progress = ProgressBar::new(zsh.loc);
-
-    let buf_size = 100;
     let mut buf = Vec::<History>::with_capacity(buf_size);
-
-    for i in zsh
+    for chunk in contents
+        .into_iter()
         .filter_map(Result::ok)
-        .filter(|x| !x.command.trim().is_empty())
+        .chunks(buf_size)
+        .into_iter()
     {
-        buf.push(i);
+        buf.clear();
+        buf.extend(chunk);
 
-        if buf.len() == buf_size {
-            db.save_bulk(&buf).await?;
-            progress.inc(buf.len() as u64);
-
-            buf.clear();
-        }
-    }
-
-    if !buf.is_empty() {
-        db.save_bulk(&buf).await?;
-        progress.inc(buf.len() as u64);
-    }
-
-    progress.finish();
-    println!("Import complete!");
-
-    Ok(())
-}
-
-// TODO: don't just copy paste this lol
-async fn import_bash(db: &mut (impl Database + Send + Sync)) -> Result<()> {
-    // oh-my-zsh sets HISTFILE=~/.zhistory
-    // zsh has no default value for this var, but uses ~/.zhistory.
-    // we could maybe be smarter about this in the future :)
-
-    let histpath = env::var("HISTFILE");
-
-    let histpath = if let Ok(p) = histpath {
-        let histpath = PathBuf::from(p);
-
-        if !histpath.exists() {
-            return Err(eyre!(
-                "Could not find history file {:?}. try updating $HISTFILE",
-                histpath
-            ));
-        }
-
-        histpath
-    } else {
-        let user_dirs = UserDirs::new().unwrap();
-        let home_dir = user_dirs.home_dir();
-
-        home_dir.join(".bash_history")
-    };
-
-    let bash = Bash::new(histpath)?;
-
-    let progress = ProgressBar::new(bash.loc);
-
-    let buf_size = 100;
-    let mut buf = Vec::<History>::with_capacity(buf_size);
-
-    for i in bash
-        .filter_map(Result::ok)
-        .filter(|x| !x.command.trim().is_empty())
-    {
-        buf.push(i);
-
-        if buf.len() == buf_size {
-            db.save_bulk(&buf).await?;
-            progress.inc(buf.len() as u64);
-
-            buf.clear();
-        }
-    }
-
-    if !buf.is_empty() {
         db.save_bulk(&buf).await?;
         progress.inc(buf.len() as u64);
     }


### PR DESCRIPTION
Creates a new trait
```rust
pub trait Importer: IntoIterator<Item = Result<History>> + Sized {
    const NAME: &'static str;
    fn histpath() -> Result<PathBuf>;
    fn parse(path: impl AsRef<Path>) -> Result<Self>;
}
```
and a function `import` which will use the provided `Importer` type to perform a generic import.

It will:
1. Check for a `$HISTFILE` or call `I::histpath()?`
2. Check that the history file is a file (#66)
3. Parse the history file
4. Iterate over the parsed contents, saving them to the DB in batches

TODO: Tests :)