### PR TITLE
Support fulltext search of commands

### DIFF
--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -35,7 +35,12 @@ pub trait Database {
     async fn last(&self) -> Result<History>;
     async fn before(&self, timestamp: chrono::DateTime<Utc>, count: i64) -> Result<Vec<History>>;
 
-    async fn search(&self, limit: Option<i64>, search_mode: SearchMode, query: &str) -> Result<Vec<History>>;
+    async fn search(
+        &self,
+        limit: Option<i64>,
+        search_mode: SearchMode,
+        query: &str,
+    ) -> Result<Vec<History>>;
 
     async fn query_history(&self, query: &str) -> Result<Vec<History>>;
 }
@@ -186,7 +191,7 @@ impl Database for Sqlite {
             // inject the unique check
             if unique {
                 "where timestamp = (
-                        select max(timestamp) from history 
+                        select max(timestamp) from history
                         where h.command = history.command
                     )"
             } else {
@@ -269,21 +274,26 @@ impl Database for Sqlite {
         Ok(res.0)
     }
 
-    async fn search(&self, limit: Option<i64>, search_mode: SearchMode, query: &str) -> Result<Vec<History>> {
+    async fn search(
+        &self,
+        limit: Option<i64>,
+        search_mode: SearchMode,
+        query: &str,
+    ) -> Result<Vec<History>> {
         let query = query.to_string().replace("*", "%"); // allow wildcard char
         let limit = limit.map_or("".to_owned(), |l| format!("limit {}", l));
 
         let query = match search_mode {
             SearchMode::Prefix => query,
-            SearchMode::FullText => format!("%{}", query)
+            SearchMode::FullText => format!("%{}", query),
         };
 
         let res = sqlx::query(
             format!(
                 "select * from history h
-            where command like ?1 || '%' 
+            where command like ?1 || '%'
             and timestamp = (
-                    select max(timestamp) from history 
+                    select max(timestamp) from history
                     where h.command = history.command
                 )
             order by timestamp desc {}",

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -10,6 +10,15 @@ use parse_duration::parse;
 
 pub const HISTORY_PAGE_SIZE: i64 = 100;
 
+#[derive(Clone, Debug, Deserialize, Copy)]
+pub enum SearchMode {
+    #[serde(rename = "prefix")]
+    Prefix,
+
+    #[serde(rename = "fulltext")]
+    FullText,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct Settings {
     pub dialect: String,
@@ -19,6 +28,7 @@ pub struct Settings {
     pub db_path: String,
     pub key_path: String,
     pub session_path: String,
+    pub search_mode: SearchMode,
 
     // This is automatically loaded when settings is created. Do not set in
     // config! Keep secrets and settings apart.
@@ -100,6 +110,7 @@ impl Settings {
         s.set_default("auto_sync", true)?;
         s.set_default("sync_frequency", "1h")?;
         s.set_default("sync_address", "https://api.atuin.sh")?;
+        s.set_default("search_mode", "prefix")?;
 
         if config_file.exists() {
             s.merge(ConfigFile::with_name(config_file.to_str().unwrap()))?;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -114,6 +114,7 @@ impl AtuinCmd {
                 query,
             } => {
                 search::run(
+                    &client_settings,
                     cwd,
                     exit,
                     interactive,

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -16,6 +16,7 @@ use unicode_width::UnicodeWidthStr;
 
 use atuin_client::database::Database;
 use atuin_client::history::History;
+use atuin_client::settings::{Settings, SearchMode};
 
 use crate::command::event::{Event, Events};
 
@@ -130,10 +131,10 @@ impl State {
     }
 }
 
-async fn query_results(app: &mut State, db: &mut (impl Database + Send + Sync)) -> Result<()> {
+async fn query_results(app: &mut State, search_mode: SearchMode, db: &mut (impl Database + Send + Sync)) -> Result<()> {
     let results = match app.input.as_str() {
         "" => db.list(Some(200), true).await?,
-        i => db.search(Some(200), &format!("*{}", i)).await?,
+        i => db.search(Some(200), search_mode, i).await?,
     };
 
     app.results = results;
@@ -149,6 +150,7 @@ async fn query_results(app: &mut State, db: &mut (impl Database + Send + Sync)) 
 
 async fn key_handler(
     input: Key,
+    search_mode: SearchMode,
     db: &mut (impl Database + Send + Sync),
     app: &mut State,
 ) -> Option<String> {
@@ -165,11 +167,11 @@ async fn key_handler(
         }
         Key::Char(c) => {
             app.input.push(c);
-            query_results(app, db).await.unwrap();
+            query_results(app, search_mode, db).await.unwrap();
         }
         Key::Backspace => {
             app.input.pop();
-            query_results(app, db).await.unwrap();
+            query_results(app, search_mode, db).await.unwrap();
         }
         Key::Down => {
             let i = match app.results_state.selected() {
@@ -277,6 +279,7 @@ fn draw<T: Backend>(f: &mut Frame<'_, T>, history_count: i64, app: &mut State) {
 #[allow(clippy::clippy::cast_possible_truncation)]
 async fn select_history(
     query: &[String],
+    search_mode: SearchMode,
     db: &mut (impl Database + Send + Sync),
 ) -> Result<String> {
     let stdout = stdout().into_raw_mode()?;
@@ -294,13 +297,13 @@ async fn select_history(
         results_state: ListState::default(),
     };
 
-    query_results(&mut app, db).await?;
+    query_results(&mut app, search_mode, db).await?;
 
     loop {
         let history_count = db.history_count().await?;
         // Handle input
         if let Event::Input(input) = events.next()? {
-            if let Some(output) = key_handler(input, db, &mut app).await {
+            if let Some(output) = key_handler(input, search_mode, db, &mut app).await {
                 return Ok(output);
             }
         }
@@ -313,6 +316,7 @@ async fn select_history(
 // it is going to have a lot of args
 #[allow(clippy::clippy::clippy::too_many_arguments)]
 pub async fn run(
+    settings: &Settings,
     cwd: Option<String>,
     exit: Option<i64>,
     interactive: bool,
@@ -339,10 +343,10 @@ pub async fn run(
     };
 
     if interactive {
-        let item = select_history(query, db).await?;
+        let item = select_history(query, settings.search_mode, db).await?;
         eprintln!("{}", item);
     } else {
-        let results = db.search(None, query.join(" ").as_str()).await?;
+        let results = db.search(None, settings.search_mode, query.join(" ").as_str()).await?;
 
         // TODO: This filtering would be better done in the SQL query, I just
         // need a nice way of building queries.

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -133,7 +133,7 @@ impl State {
 async fn query_results(app: &mut State, db: &mut (impl Database + Send + Sync)) -> Result<()> {
     let results = match app.input.as_str() {
         "" => db.list(Some(200), true).await?,
-        i => db.search(Some(200), &("*".to_owned() + &i)).await?,
+        i => db.search(Some(200), &format!("*{}", i)).await?,
     };
 
     app.results = results;

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -16,7 +16,7 @@ use unicode_width::UnicodeWidthStr;
 
 use atuin_client::database::Database;
 use atuin_client::history::History;
-use atuin_client::settings::{Settings, SearchMode};
+use atuin_client::settings::{SearchMode, Settings};
 
 use crate::command::event::{Event, Events};
 
@@ -131,7 +131,11 @@ impl State {
     }
 }
 
-async fn query_results(app: &mut State, search_mode: SearchMode, db: &mut (impl Database + Send + Sync)) -> Result<()> {
+async fn query_results(
+    app: &mut State,
+    search_mode: SearchMode,
+    db: &mut (impl Database + Send + Sync),
+) -> Result<()> {
     let results = match app.input.as_str() {
         "" => db.list(Some(200), true).await?,
         i => db.search(Some(200), search_mode, i).await?,
@@ -346,7 +350,9 @@ pub async fn run(
         let item = select_history(query, settings.search_mode, db).await?;
         eprintln!("{}", item);
     } else {
-        let results = db.search(None, settings.search_mode, query.join(" ").as_str()).await?;
+        let results = db
+            .search(None, settings.search_mode, query.join(" ").as_str())
+            .await?;
 
         // TODO: This filtering would be better done in the SQL query, I just
         // need a nice way of building queries.

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -133,7 +133,7 @@ impl State {
 async fn query_results(app: &mut State, db: &mut (impl Database + Send + Sync)) -> Result<()> {
     let results = match app.input.as_str() {
         "" => db.list(Some(200), true).await?,
-        i => db.search(Some(200), i).await?,
+        i => db.search(Some(200), &("*".to_owned() + &i)).await?,
     };
 
     app.results = results;


### PR DESCRIPTION
Support fulltext search mode.

Fulltext search will report partial matches of commands, not just prefix
matches. Matches ctrl-r default behavior (on zsh at least).


TODO:

- <s>Is the way I'm doing string concat idiomatic rust?</s> It wasn't, but it is now
- <s>Should this be toggleable behind a config options?</s> Yes
- <s>Should this be a param to db.query method, toggling fulltext vs prefix search?</s> Yes

Fixes https://github.com/ellie/atuin/issues/72