### PR TITLE
Implement 'quick access' via Alt-<n>

### DIFF
--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -99,18 +99,19 @@ impl State {
 
                 let selected_index = match self.results_state.selected() {
                     None => Span::raw("   "),
-                    Some(selected) => {
-                        match i.checked_sub(selected) {
-                            None => Span::raw("   "),
-                            Some(diff) => {
-                                if 0 < diff && diff < 10 {
-                                    Span::styled(format!(" {} ", diff), Style::default().fg(Color::DarkGray))
-                                } else {
-                                    Span::raw("   ")
-                                }
+                    Some(selected) => match i.checked_sub(selected) {
+                        None => Span::raw("   "),
+                        Some(diff) => {
+                            if 0 < diff && diff < 10 {
+                                Span::styled(
+                                    format!(" {} ", diff),
+                                    Style::default().fg(Color::DarkGray),
+                                )
+                            } else {
+                                Span::raw("   ")
                             }
                         }
-                    }
+                    },
                 };
 
                 let duration = Span::styled(
@@ -131,8 +132,14 @@ impl State {
                     }
                 }
 
-                let spans =
-                    Spans::from(vec![selected_index, duration, Span::raw(" "), ago, Span::raw(" "), command]);
+                let spans = Spans::from(vec![
+                    selected_index,
+                    duration,
+                    Span::raw(" "),
+                    ago,
+                    Span::raw(" "),
+                    command,
+                ]);
 
                 ListItem::new(spans)
             })
@@ -189,9 +196,7 @@ async fn key_handler(
             let c = c.to_digit(10)? as usize;
             let i = match app.results_state.selected() {
                 None => return None,
-                Some(selected) => {
-                    c + selected
-                }
+                Some(selected) => c + selected,
             };
 
             return Some(

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -185,10 +185,14 @@ async fn key_handler(
                     .map_or(app.input.clone(), |h| h.command.clone()),
             );
         }
-        Key::Ctrl(c) if ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].contains(&c) => {
-            // FIXME: This doesn't work since Ctrl+<num> are reserved and don't pass through to programs
+        Key::Alt(c) if ['1', '2', '3', '4', '5', '6', '7', '8', '9'].contains(&c) => {
             let c = c.to_digit(10)? as usize;
-            let i = app.results_state.selected().unwrap_or(0).checked_sub(c)?;
+            let i = match app.results_state.selected() {
+                None => return None,
+                Some(selected) => {
+                    c + selected
+                }
+            };
 
             return Some(
                 app.results

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -192,12 +192,9 @@ async fn key_handler(
                     .map_or(app.input.clone(), |h| h.command.clone()),
             );
         }
-        Key::Alt(c) if ['1', '2', '3', '4', '5', '6', '7', '8', '9'].contains(&c) => {
+        Key::Alt(c) if ('1'..='9').contains(&c) => {
             let c = c.to_digit(10)? as usize;
-            let i = match app.results_state.selected() {
-                None => return None,
-                Some(selected) => c + selected,
-            };
+            let i = app.results_state.selected()? + c;
 
             return Some(
                 app.results

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -103,7 +103,7 @@ impl State {
                         match i.checked_sub(selected) {
                             None => Span::raw("   "),
                             Some(diff) => {
-                                if diff < 10 {
+                                if 0 < diff && diff < 10 {
                                     Span::styled(format!(" {} ", diff), Style::default().fg(Color::DarkGray))
                                 } else {
                                     Span::raw("   ")


### PR DESCRIPTION
Puts numbers 0-9 next to commands *above* current selection.
Ctrl-<number> should activate them - but since Ctrl-<num> are
reserved by terminal, this does not currently work. Need to
find different sets of keyboard shortcuts.

Numbers are *above* current selection, since the user must use
the arrow keys to go over the commands below current selection
before reaching selection.

<img width="476" alt="image" src="https://user-images.githubusercontent.com/30430/117564644-ba468c00-b0ca-11eb-8fa1-eca362b1bf1b.png">
