### PR TITLE
Allow listing or searching with only the command as output

### DIFF
--- a/src/command/history.rs
+++ b/src/command/history.rs
@@ -42,6 +42,9 @@ pub enum Cmd {
 
         #[structopt(long, short)]
         human: bool,
+
+        #[structopt(long, about = "Show only the text of the command")]
+        cmd_only: bool,
     },
 
     #[structopt(
@@ -51,11 +54,14 @@ pub enum Cmd {
     Last {
         #[structopt(long, short)]
         human: bool,
+
+        #[structopt(long, about = "Show only the text of the command")]
+        cmd_only: bool,
     },
 }
 
 #[allow(clippy::clippy::cast_sign_loss)]
-pub fn print_list(h: &[History], human: bool) {
+pub fn print_list(h: &[History], human: bool, cmd_only: bool) {
     let mut writer = TabWriter::new(std::io::stdout()).padding(2);
 
     let lines = h.iter().map(|h| {
@@ -73,6 +79,8 @@ pub fn print_list(h: &[History], human: bool) {
                 h.command.trim(),
                 duration,
             )
+        } else if cmd_only {
+            format!("{}\n", h.command.trim())
         } else {
             format!(
                 "{}\t{}\t{}\n",
@@ -145,6 +153,7 @@ impl Cmd {
                 session,
                 cwd,
                 human,
+                cmd_only,
             } => {
                 let params = (session, cwd);
                 let cwd = env::current_dir()?.display().to_string();
@@ -165,14 +174,14 @@ impl Cmd {
                     (true, true) => db.query_history(query_session_dir.as_str()).await?,
                 };
 
-                print_list(&history, *human);
+                print_list(&history, *human, *cmd_only);
 
                 Ok(())
             }
 
-            Self::Last { human } => {
+            Self::Last { human, cmd_only } => {
                 let last = db.last().await?;
-                print_list(&[last], *human);
+                print_list(&[last], *human, *cmd_only);
 
                 Ok(())
             }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -69,6 +69,9 @@ pub enum AtuinCmd {
         human: bool,
 
         query: Vec<String>,
+
+        #[structopt(long, about = "Show only the text of the command")]
+        cmd_only: bool,
     },
 
     #[structopt(about = "sync with the configured server")]
@@ -112,6 +115,7 @@ impl AtuinCmd {
                 before,
                 after,
                 query,
+                cmd_only,
             } => {
                 search::run(
                     &client_settings,
@@ -123,6 +127,7 @@ impl AtuinCmd {
                     exclude_cwd,
                     before,
                     after,
+                    cmd_only,
                     &query,
                     &mut db,
                 )

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -329,6 +329,7 @@ pub async fn run(
     exclude_cwd: Option<String>,
     before: Option<String>,
     after: Option<String>,
+    cmd_only: bool,
     query: &[String],
     db: &mut (impl Database + Send + Sync),
 ) -> Result<()> {
@@ -412,7 +413,7 @@ pub async fn run(
             .map(std::borrow::ToOwned::to_owned)
             .collect();
 
-        super::history::print_list(&results, human);
+        super::history::print_list(&results, human, cmd_only);
     }
 
     Ok(())


### PR DESCRIPTION
Should be useful for using other tools, such as FZF

Ref #68 