### PR TITLE
fix some bugs

### DIFF
--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -98,13 +98,11 @@ impl Settings {
 
     pub fn new() -> Result<Self> {
         let config_dir = atuin_common::utils::config_dir();
-        let config_dir = config_dir.as_path();
 
         let data_dir = atuin_common::utils::data_dir();
-        let data_dir = data_dir.as_path();
 
-        create_dir_all(config_dir)?;
-        create_dir_all(data_dir)?;
+        create_dir_all(&config_dir)?;
+        create_dir_all(&data_dir)?;
 
         let mut config_file = if let Ok(p) = std::env::var("ATUIN_CONFIG_DIR") {
             PathBuf::from(p)


### PR DESCRIPTION
A couple bugs I spotted. First, if `XDG_*_DIR` environment paths are chosen, then `atuin` isn't joined to the end and so the config just goes into `$HOME/.config` rather than `$HOME/.config/atuin`.

Also, `$ATUIN_SESSION` isn't always used in the `atuin history list` command, so let's not fail if it's missing.