### PR TITLE
Fix resh importer crashing on end of file

### DIFF
--- a/atuin-client/src/import/resh.rs
+++ b/atuin-client/src/import/resh.rs
@@ -112,8 +112,12 @@ impl Iterator for Resh {
             Err(e) => return Some(Err(eyre!("failed to read line: {}", e))), // we can skip past things like invalid utf8
         }
 
+        // .resh_history.json lies about being a json. It is actually a file containing valid json
+        // on every line. This means that the last line will throw an error, as it is just an EOF.
+        // Without the special case here, that will crash the importer.
         let entry = match serde_json::from_str::<ReshEntry>(&self.strbuf) {
             Ok(e) => e,
+            Err(e) if e.is_eof() => return None,
             Err(e) => {
                 return Some(Err(eyre!(
                     "Invalid entry found in resh_history file: {}",


### PR DESCRIPTION
This change was made in #82 , but was missed out when it was converted to use the generic trait (in #71).