### PR TITLE
Increase number of optimizations on release builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,8 @@ base64 = "0.13.0"
 humantime = "2.1.0"
 tabwriter = "1.2.1"
 crossbeam-channel = "0.5.1"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+opt-level = 3


### PR DESCRIPTION
This allows us to produce a faster executable (which is useful in shells) at the expense of rarely spending more compilation time upon releasing a new version.
I do this in all of my rust projects, perhaps because they are too small for compilation time to really matter. We should measure next time we release and see how that goes.