### PR TITLE
Re-add macro_use to atuin-common

### DIFF
--- a/atuin-common/src/lib.rs
+++ b/atuin-common/src/lib.rs
@@ -1,4 +1,7 @@
 #![forbid(unsafe_code)]
 
+#[macro_use]
+extern crate serde_derive;
+
 pub mod api;
 pub mod utils;


### PR DESCRIPTION
When build as a dependency, the macro is available from another crate.
When you try to build common by itself, the macro is not found. Magic,
huh?
