### PR TITLE
Add fuzzy text search mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +156,7 @@ dependencies = [
  "sodiumoxide",
  "sqlx",
  "tokio",
+ "tokio-test",
  "urlencoding",
  "uuid",
  "whoami",
@@ -2322,6 +2344,19 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -17,7 +17,6 @@ log = "0.4"
 fern = {version = "0.6.0", features = ["colored"] }
 chrono = { version = "0.4", features = ["serde"] }
 eyre = "0.6"
-tokio-test = "*"
 directories = "3"
 uuid = { version = "0.8", features = ["v4"] }
 indicatif = "0.16.0"
@@ -41,3 +40,6 @@ humantime = "2.1.0"
 itertools = "0.10.0"
 shellexpand = "2"
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "uuid", "chrono", "sqlite" ] }
+
+[dev-dependencies]
+tokio-test = "*"

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4"
 fern = {version = "0.6.0", features = ["colored"] }
 chrono = { version = "0.4", features = ["serde"] }
 eyre = "0.6"
+tokio-test = "*"
 directories = "3"
 uuid = { version = "0.8", features = ["v4"] }
 indicatif = "0.16.0"

--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -24,5 +24,5 @@
 # sync_address = "https://api.atuin.sh"
 
 ## which search mode to use
-## possible values: prefix, fulltext
+## possible values: prefix, fulltext, fuzzy
 # search_mode = "prefix"

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -6,6 +6,7 @@ use chrono::prelude::*;
 use chrono::Utc;
 
 use eyre::Result;
+use itertools::Itertools;
 
 use sqlx::sqlite::{
     SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow,
@@ -286,7 +287,7 @@ impl Database for Sqlite {
         let query = match search_mode {
             SearchMode::Prefix => query,
             SearchMode::FullText => format!("%{}", query),
-            SearchMode::Fuzzy => query.split("").collect::<Vec<&str>>().join("%"),
+            SearchMode::Fuzzy => query.split("").join("%"),
         };
 
         let res = sqlx::query(

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -17,6 +17,9 @@ pub enum SearchMode {
 
     #[serde(rename = "fulltext")]
     FullText,
+
+    #[serde(rename = "fuzzy")]
+    Fuzzy,
 }
 
 // FIXME: Can use upstream Dialect enum if https://github.com/stevedonovan/chrono-english/pull/16 is merged

--- a/docs/config.md
+++ b/docs/config.md
@@ -96,8 +96,8 @@ key = "~/.atuin-session"
 
 ### `search_mode`
 
-Which search mode to use. Atuin supports both "prefix" and full text search
-modes. The former will essentially search for "query*", and the latter "*query\*"
+Which search mode to use. Atuin supports "prefix", full text and "fuzzy" search
+modes. The prefix search for "query\*", fulltext "\*query\*", and fuzzy "\*q\*u\*e\*r\*y\*"
 
 Defaults to "prefix"
 


### PR DESCRIPTION
Adds a new search mode "fuzzy" which matches as long as the characters in the query exist somewhere in the command in the same order. This is how e.g. SublimeText cmd+P search works

I'm a little worried about performance with large database files. With a ~1000 item database locally it runs no problem