### PR TITLE
feat: allow input of credentials from stdin

### DIFF
--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -1,6 +1,6 @@
+use std::io;
 use std::io::prelude::*;
 use std::{borrow::Cow, fs::File};
-use std::io;
 
 use atuin_common::api::LoginRequest;
 use eyre::Result;
@@ -40,19 +40,24 @@ impl Cmd {
             return Ok(());
         }
 
-
         // TODO: Maybe get rid of clone
-        let username = if let Some(username) = self.username.clone() { username } else {
+        let username = if let Some(username) = self.username.clone() {
+            username
+        } else {
             eprint!("Please enter username: ");
             get_input().expect("Failed to read username from input")
         };
 
-        let password = if let Some(password) = self.password.clone() { password } else {
+        let password = if let Some(password) = self.password.clone() {
+            password
+        } else {
             eprint!("Please enter password: ");
             get_input().expect("Failed to read email from input")
         };
 
-        let key = if let Some(key) = self.key.clone() { key } else {
+        let key = if let Some(key) = self.key.clone() {
+            key
+        } else {
             eprint!("Please enter encryption key: ");
             get_input().expect("Failed to read password from input")
         };

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -147,12 +147,7 @@ impl AtuinCmd {
                 logout::run();
                 Ok(())
             }
-            Self::Register(r) => register::run(
-                &client_settings,
-                r.username,
-                r.email,
-                r.password,
-            ),
+            Self::Register(r) => register::run(&client_settings, r.username, r.email, r.password),
             Self::Key => {
                 let key = atuin_client::encryption::load_key(&client_settings)?;
                 println!("{}", atuin_client::encryption::encode_key(key)?);

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -149,9 +149,9 @@ impl AtuinCmd {
             }
             Self::Register(r) => register::run(
                 &client_settings,
-                r.username.as_str(),
-                r.email.as_str(),
-                r.password.as_str(),
+                r.username,
+                r.email,
+                r.password,
             ),
             Self::Key => {
                 let key = atuin_client::encryption::load_key(&client_settings)?;

--- a/src/command/register.rs
+++ b/src/command/register.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
-use std::io::prelude::*;
 use std::io;
+use std::io::prelude::*;
 
 use eyre::Result;
 use structopt::StructOpt;
@@ -27,23 +27,39 @@ fn get_input() -> Result<String> {
     Ok(input.trim_end_matches(&['\r', '\n'][..]).to_string())
 }
 
-pub fn run(settings: &Settings, username: Option<String>, email: Option<String>, password: Option<String>) -> Result<()> {
-    let username = if let Some(username) = username { username } else {
+pub fn run(
+    settings: &Settings,
+    username: Option<String>,
+    email: Option<String>,
+    password: Option<String>,
+) -> Result<()> {
+    let username = if let Some(username) = username {
+        username
+    } else {
         eprint!("Please enter username: ");
         get_input().expect("Failed to read username from input")
     };
 
-    let email = if let Some(email) = email { email } else {
+    let email = if let Some(email) = email {
+        email
+    } else {
         eprint!("Please enter email: ");
         get_input().expect("Failed to read email from input")
     };
 
-    let password = if let Some(password) = password { password } else {
+    let password = if let Some(password) = password {
+        password
+    } else {
         eprint!("Please enter password: ");
         get_input().expect("Failed to read password from input")
     };
 
-    let session = api_client::register(settings.sync_address.as_str(), username.as_str(), email.as_str(), password.as_str())?;
+    let session = api_client::register(
+        settings.sync_address.as_str(),
+        username.as_str(),
+        email.as_str(),
+        password.as_str(),
+    )?;
 
     let path = settings.session_path.as_str();
     let mut file = File::create(path)?;


### PR DESCRIPTION
This changes the arguments for `register` and `login` to be optional. If any arguments are not given, their content will be asked for interactively. 

This was added, because command-line arguments are readable system-wide in the process list and end up in the history. (See  #183)

Also: Great Project ^^

Closes:  #183