### PR TITLE
Resolve clippy warnings

### DIFF
--- a/src/command/history.rs
+++ b/src/command/history.rs
@@ -60,7 +60,7 @@ pub enum Cmd {
     },
 }
 
-#[allow(clippy::clippy::cast_sign_loss)]
+#[allow(clippy::cast_sign_loss)]
 pub fn print_list(h: &[History], human: bool, cmd_only: bool) {
     let mut writer = TabWriter::new(std::io::stdout()).padding(2);
 

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -1,4 +1,3 @@
-use eyre::Result;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -20,11 +19,10 @@ fn init_bash() {
 }
 
 impl Cmd {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self) {
         match self {
             Self::Zsh => init_zsh(),
             Self::Bash => init_bash(),
         }
-        Ok(())
     }
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -111,7 +111,7 @@ impl AtuinCmd {
             Self::Init(init) => {
                 init.run();
                 Ok(())
-            },
+            }
             Self::Search {
                 cwd,
                 exit,

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -108,7 +108,10 @@ impl AtuinCmd {
             Self::Import(import) => import.run(&mut db).await,
             Self::Server(server) => server.run(&server_settings).await,
             Self::Stats(stats) => stats.run(&mut db, &client_settings).await,
-            Self::Init(init) => init.run(),
+            Self::Init(init) => {
+                init.run();
+                Ok(())
+            },
             Self::Search {
                 cwd,
                 exit,

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -31,7 +31,7 @@ struct State {
 }
 
 impl State {
-    #[allow(clippy::clippy::cast_sign_loss)]
+    #[allow(clippy::cast_sign_loss)]
     fn durations(&self) -> Vec<(String, String)> {
         self.results
             .iter()
@@ -241,7 +241,7 @@ async fn key_handler(
     None
 }
 
-#[allow(clippy::clippy::cast_possible_truncation)]
+#[allow(clippy::cast_possible_truncation)]
 fn draw<T: Backend>(f: &mut Frame<'_, T>, history_count: i64, app: &mut State) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -312,7 +312,7 @@ fn draw<T: Backend>(f: &mut Frame<'_, T>, history_count: i64, app: &mut State) {
 // this is a big blob of horrible! clean it up!
 // for now, it works. But it'd be great if it were more easily readable, and
 // modular. I'd like to add some more stats and stuff at some point
-#[allow(clippy::clippy::cast_possible_truncation)]
+#[allow(clippy::cast_possible_truncation)]
 async fn select_history(
     query: &[String],
     search_mode: SearchMode,
@@ -350,7 +350,7 @@ async fn select_history(
 
 // This is supposed to more-or-less mirror the command line version, so ofc
 // it is going to have a lot of args
-#[allow(clippy::clippy::clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     settings: &Settings,
     cwd: Option<String>,

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -179,7 +179,7 @@ async fn key_handler(
     app: &mut State,
 ) -> Option<String> {
     match input {
-        Key::Esc | Key::Ctrl('c') | Key::Ctrl('d') | Key::Ctrl('g') => {
+        Key::Esc | Key::Ctrl('c' | 'd' | 'g') => {
             return Some(String::from(""))
         }
         Key::Char('\n') => {

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -179,9 +179,7 @@ async fn key_handler(
     app: &mut State,
 ) -> Option<String> {
     match input {
-        Key::Esc | Key::Ctrl('c' | 'd' | 'g') => {
-            return Some(String::from(""))
-        }
+        Key::Esc | Key::Ctrl('c' | 'd' | 'g') => return Some(String::from("")),
         Key::Char('\n') => {
             let i = app.results_state.selected().unwrap_or(0);
 


### PR DESCRIPTION
The GitHub workflow configuration uses `cargo clippy -- -D warnings` which disallows warning. Therefore the workflow tests don't succeed. This fixes the annotations and code clippy warns about.