### PR TITLE
fix: dockerfile with correct glibc

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -19,19 +19,50 @@ OPTIONS:
     -p, --port <port>
 ```
 
+## Configuration
+
 The config for the server is kept separate from the config for the client, even
 though they are the same binary. Server config can be found at
 `~/.config/atuin/server.toml`.
 
 It looks something like this:
 
-```
+```toml
 host = "0.0.0.0"
 port = 8888
 open_registration = true
 db_uri="postgres://user:password@hostname/database"
 ```
 
-`open_registration` sets whether the server allows new user registrations. Set
-this to false after making your own account if you don't want others to be able
-to use your server.
+Alternatively, configuration can also be provided with environment variables.
+
+```sh
+ATUIN_HOST="0.0.0.0"
+ATUIN_PORT=8888
+ATUIN_OPEN_REGISTRATION=true
+ATUIN_DB_URI="postgres://user:password@hostname/database"
+```
+
+### host
+
+The host address the atuin server should listen on.
+
+Defaults to `127.0.0.1`.
+
+### port
+
+The post the atuin server should listen on.
+
+Defaults to `8888`.
+
+### open_registration
+
+If `true`, atuin will accept new user registrations.
+Set this to `false` after making your own account if you don't want others to be
+able to use your server.
+
+Defaults to `false`.
+
+### db_uri
+
+A valid postgres URI, where the user and history data will be saved to.


### PR DESCRIPTION
A small partial fix for #197 to make sure the dockerfile is up to date. Also pins the images so it won't break in future.

The changes to `cargo-chef` are just making it more like the new suggested dockerfile from their repo.