### PR TITLE
chore: supply pre-build docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,58 @@
+name: Build docker image
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    name: build and publish atuin image
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/atuin
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/docs/server.md
+++ b/docs/server.md
@@ -35,3 +35,11 @@ db_uri="postgres://user:password@hostname/database"
 `open_registration` sets whether the server allows new user registrations. Set
 this to false after making your own account if you don't want others to be able
 to use your server.
+
+## Docker
+
+There is a supplied docker image to make deploying a server as a container easier.
+
+```sh
+docker run -d -v "$USER/.config/atuin:/config" ghcr.io/ellie/atuin:latest server start
+```


### PR DESCRIPTION
Publish a docker image for each merge and each release for easier deployment for users wanting to host their own server