### PR TITLE
chore: improve build times

### DIFF
--- a/atuin-server/src/router.rs
+++ b/atuin-server/src/router.rs
@@ -66,7 +66,8 @@ pub async fn router(
         .and(warp::path::end())
         .and(with_user(postgres.clone()))
         .and(with_db(postgres.clone()))
-        .and_then(handlers::history::count);
+        .and_then(handlers::history::count)
+        .boxed();
 
     let sync = warp::get()
         .and(warp::path("sync"))
@@ -75,7 +76,8 @@ pub async fn router(
         .and(warp::path::end())
         .and(with_user(postgres.clone()))
         .and(with_db(postgres.clone()))
-        .and_then(handlers::history::list);
+        .and_then(handlers::history::list)
+        .boxed();
 
     let add_history = warp::post()
         .and(warp::path("history"))
@@ -83,14 +85,16 @@ pub async fn router(
         .and(warp::body::json())
         .and(with_user(postgres.clone()))
         .and(with_db(postgres.clone()))
-        .and_then(handlers::history::add);
+        .and_then(handlers::history::add)
+        .boxed();
 
     let user = warp::get()
         .and(warp::path("user"))
         .and(warp::path::param::<String>())
         .and(warp::path::end())
         .and(with_db(postgres.clone()))
-        .and_then(handlers::user::get);
+        .and_then(handlers::user::get)
+        .boxed();
 
     let register = warp::post()
         .and(warp::path("register"))
@@ -98,14 +102,16 @@ pub async fn router(
         .and(warp::body::json())
         .and(with_settings(settings.clone()))
         .and(with_db(postgres.clone()))
-        .and_then(handlers::user::register);
+        .and_then(handlers::user::register)
+        .boxed();
 
     let login = warp::post()
         .and(warp::path("login"))
         .and(warp::path::end())
         .and(warp::body::json())
         .and(with_db(postgres))
-        .and_then(handlers::user::login);
+        .and_then(handlers::user::login)
+        .boxed();
 
     let r = warp::any()
         .and(


### PR DESCRIPTION
This simple change ended up improving the install time for me from `2:30s` to `20s`. Warp is very type heavy, and super complex types cause the compiler to be bottlenecked. When profiling, I found that rustc spent almost minute alone on monomorphisation.

You'd think that since this code is in the server crate, that you could just build that once and it would improve the build times in the core atuin bin, but that's sadly not the case.

Since this optimisation helps more in multithreaded workflows, github actions does not take full advantage of this since it uses single threaded VMs so the difference isn't noticeable there

Note:
It's worth noting that this adds a little bit of overhead to the server routes due to dynamic dispatch. But it's probably negligible