### PR TITLE
Remove dev dep with wildcard

### DIFF
--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -41,6 +41,3 @@ itertools = "0.10.1"
 shellexpand = "2"
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "uuid", "chrono", "sqlite" ] }
 minspan = "0.1.1"
-
-[dev-dependencies]
-tokio-test = "*"


### PR DESCRIPTION
I can't publish to crates.io because of a wildcard dev dependency. Oops. 

It's not needed anyway