### PR TITLE
Update messages in install.sh about the AUR packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ __atuin_install_arch(){
 			echo "Found pamac"
 			pamac install atuin
 		else
-			echo "Failed to install atuin! Please try manually: https://aur.archlinux.org/packages/atuin/"
+			echo "Failed to install atuin! Please try manually: https://aur.archlinux.org/packages/atuin-git/"
 		fi
 	fi
 

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ __atuin_install_linux(){
     else
         if ! command -v lsb_release &> /dev/null; then
             echo "lsb_release could not be found, unable to determine your distribution"
-            echo "If you are using Arch, please get lsb_release from AUR"
+            echo "If you are using Arch Linux, please get community/lsb-release"
             exit 1
         fi
         OS=$(lsb_release -i | awk '{ print $3 }')


### PR DESCRIPTION
Hello again! :bear:

I realized `install.sh` suggests using to the [atuin](https://aur.archlinux.org/packages/atuin) package for manual installation. However, that package is going to be removed soon. Also, I saw that there are no VCS or upstream-binary packages in the AUR. So I created them and changed that message to redirect users to the `-git` package instead.

- https://aur.archlinux.org/packages/atuin-git/ (VCS package) 
- https://aur.archlinux.org/packages/atuin-bin/ (Upstream binary package which is built on CD)

P.S. I also pushed e2ac898, which is a minor fix about suggesting Arch Linux users to install `lsb-release` from the community repository.

