### PR TITLE
Fish importing

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,16 @@ Then setup Atuin
 echo 'eval "$(atuin init bash)"' >> ~/.bashrc
 ```
 
+### fish
+
+Add
+
+```
+atuin init fish | source
+```
+
+to your `is-interactive` block in your `~/.config/fish/config.fish` file
+
 ## ...what's with the name?
 
 Atuin is named after "The Great A'Tuin", a giant turtle from Terry Pratchett's

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ I wanted to. And I **really** don't want to.
 
 - zsh
 - bash
+- fish
 
 # Quickstart
   

--- a/atuin-client/src/import/fish.rs
+++ b/atuin-client/src/import/fish.rs
@@ -1,0 +1,129 @@
+// import old shell history!
+// automatically hoover up all that we can find
+
+use std::{
+    fs::File,
+    io::{self, BufRead, BufReader, Read, Seek},
+    path::{Path, PathBuf},
+};
+
+use chrono::prelude::*;
+use chrono::Utc;
+use directories::UserDirs;
+use eyre::{eyre, Result};
+use itertools::Itertools;
+
+use super::{count_lines, Importer};
+use crate::history::History;
+
+#[derive(Debug)]
+pub struct Fish<R> {
+    file: BufReader<R>,
+    strbuf: String,
+    loc: usize,
+}
+
+impl<R: Read + Seek> Fish<R> {
+    fn new(r: R) -> Result<Self> {
+        let mut buf = BufReader::new(r);
+        let loc = count_lines(&mut buf)?;
+
+        Ok(Self {
+            file: buf,
+            strbuf: String::new(),
+            loc,
+        })
+    }
+
+    fn new_entry(&mut self) -> io::Result<bool> {
+        let inner = self.file.fill_buf()?;
+        Ok(inner.starts_with(b"- "))
+    }
+}
+
+impl Importer for Fish<File> {
+    const NAME: &'static str = "fish";
+
+    fn histpath() -> Result<PathBuf> {
+        let user_dirs = UserDirs::new().unwrap();
+        let home_dir = user_dirs.home_dir();
+
+        let histpath = home_dir.join(".local/share/fish/fish_history");
+        if histpath.exists() {
+            Ok(histpath)
+        } else {
+            Err(eyre!("Could not find history file. Try setting $HISTFILE"))
+        }
+    }
+
+    fn parse(path: impl AsRef<Path>) -> Result<Self> {
+        Self::new(File::open(path)?)
+    }
+}
+
+impl<R: Read> Iterator for Fish<R> {
+    type Item = Result<History>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut time: Option<DateTime<Utc>> = None;
+        let mut cmd: Option<String> = None;
+
+        loop {
+            self.strbuf.clear();
+            match self.file.read_line(&mut self.strbuf) {
+                // no more content to read
+                Ok(0) => break,
+                // bail on IO error
+                e @ Err(_) => Some(e),
+                _ => (),
+            }
+
+            // `read_line` adds the line delimeter to the string. No thanks
+            self.strbuf.pop();
+
+            if let Some(c) = self.strbuf.strip_prefix("- cmd: ") {
+                // using raw strings to avoid needing escaping.
+                // replaces double backslashes with single backslashes
+                let c = c.replace(r"\\", r"\");
+                // replaces escaped newlines
+                let c = c.replace(r"\n", "\n");
+                // TODO: any other escape characters?
+
+                cmd = Some(c);
+            } else if let Some(t) = self.strbuf.strip_prefix("  when: ") {
+                // if t is not an int, just ignore this line
+                if let Ok(t) = t.parse::<i64>() {
+                    time = Some(Utc.timestamp(t, 0));
+                }
+            } else {
+                // ... ignore paths lines
+            }
+
+            if self.new_entry() {
+                // next line is a new entry, so let's stop here
+                break;
+            }
+        }
+
+        let cmd = cmd?;
+        let time = time.unwrap_or_else(|| Utc::now());
+
+        Some(Ok(History::new(
+            time,
+            cmd,
+            "unknown".into(),
+            -1,
+            -1,
+            None,
+            None,
+        )))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // worst case, entry per line
+        (0, Some(self.loc))
+    }
+}
+
+#[cfg(test)]
+mod test {}

--- a/atuin-client/src/import/fish.rs
+++ b/atuin-client/src/import/fish.rs
@@ -53,7 +53,11 @@ impl Importer for Fish<File> {
         // fish supports multiple history sessions
         // If `fish_history` var is missing, or set to `default`, use `fish` as the session
         let session = std::env::var("fish_history").unwrap_or_else(|_| String::from("fish"));
-        let session = if session == "default" { String::from("fish" )} else { session };
+        let session = if session == "default" {
+            String::from("fish")
+        } else {
+            session
+        };
 
         let mut histpath = data.join("fish");
         histpath.push(format!("{}_history", session));

--- a/atuin-client/src/import/fish.rs
+++ b/atuin-client/src/import/fish.rs
@@ -50,12 +50,13 @@ impl Importer for Fish<File> {
         let base = BaseDirs::new().ok_or_else(|| eyre!("could not determine data directory"))?;
         let data = base.data_local_dir();
 
+        // fish supports multiple history sessions
+        // If `fish_history` var is missing, or set to `default`, use `fish` as the session
+        let session = std::env::var("fish_history").unwrap_or_else(|_| String::from("fish"));
+        let session = if session == "default" { String::from("fish" )} else { session };
+
         let mut histpath = data.join("fish");
-        if let Ok(session) = std::env::var("fish_history") {
-            histpath.push(format!("{}_history", session));
-        } else {
-            histpath.push("fish_history");
-        }
+        histpath.push(format!("{}_history", session));
 
         if histpath.exists() {
             Ok(histpath)

--- a/atuin-client/src/import/fish.rs
+++ b/atuin-client/src/import/fish.rs
@@ -132,11 +132,11 @@ impl<R: Read> Iterator for Fish<R> {
 
 #[cfg(test)]
 mod test {
+    use chrono::{TimeZone, Utc};
     use std::io::Cursor;
-    use chrono::{Utc, TimeZone};
 
-    use crate::history::History;
     use super::Fish;
+    use crate::history::History;
 
     // simple wrapper for fish history entry
     macro_rules! fishtory {

--- a/atuin-client/src/import/mod.rs
+++ b/atuin-client/src/import/mod.rs
@@ -6,6 +6,7 @@ use eyre::Result;
 use crate::history::History;
 
 pub mod bash;
+pub mod fish;
 pub mod resh;
 pub mod zsh;
 

--- a/src/command/import.rs
+++ b/src/command/import.rs
@@ -1,5 +1,6 @@
 use std::{env, path::PathBuf};
 
+use atuin_client::import::fish::Fish;
 use eyre::{eyre, Result};
 use structopt::StructOpt;
 
@@ -33,6 +34,12 @@ pub enum Cmd {
         aliases=&["r", "re", "res"],
     )]
     Resh,
+
+    #[structopt(
+        about="import history from the fish history file",
+        aliases=&["f", "fi", "fis"],
+    )]
+    Fish,
 }
 
 const BATCH_SIZE: usize = 100;
@@ -54,6 +61,9 @@ impl Cmd {
                 if shell.ends_with("/zsh") {
                     println!("Detected ZSH");
                     import::<Zsh<_>, _>(db, BATCH_SIZE).await
+                } else if shell.ends_with("/fish") {
+                    println!("Detected Fish");
+                    import::<Fish<_>, _>(db, BATCH_SIZE).await
                 } else {
                     println!("cannot import {} history", shell);
                     Ok(())
@@ -63,6 +73,7 @@ impl Cmd {
             Self::Zsh => import::<Zsh<_>, _>(db, BATCH_SIZE).await,
             Self::Bash => import::<Bash<_>, _>(db, BATCH_SIZE).await,
             Self::Resh => import::<Resh, _>(db, BATCH_SIZE).await,
+            Self::Fish => import::<Fish<_>, _>(db, BATCH_SIZE).await,
         }
     }
 }

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -6,6 +6,8 @@ pub enum Cmd {
     Zsh,
     #[structopt(about = "bash setup")]
     Bash,
+    #[structopt(about = "fish setup")]
+    Fish,
 }
 
 fn init_zsh() {
@@ -18,11 +20,17 @@ fn init_bash() {
     println!("{}", full);
 }
 
+fn init_fish() {
+    let full = include_str!("../shell/atuin.fish");
+    println!("{}", full);
+}
+
 impl Cmd {
     pub fn run(&self) {
         match self {
             Self::Zsh => init_zsh(),
             Self::Bash => init_bash(),
+            Self::Fish => init_fish(),
         }
     }
 }

--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -21,6 +21,8 @@ function _atuin_search
     end
 end
 
-bind -k up '_atuin_search'
-bind \eOA '_atuin_search'
-bind \e\[A '_atuin_search'
+if test -z $ATUIN_NOBIND
+	  bind -k up '_atuin_search'
+	  bind \eOA '_atuin_search'
+	  bind \e\[A '_atuin_search'
+end

--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -1,6 +1,6 @@
 
-export ATUIN_SESSION=(atuin uuid)
-export ATUIN_HISTORY=(atuin history list)
+set -Gx ATUIN_SESSION (atuin uuid)
+set -Gx ATUIN_HISTORY (atuin history list)
 
 function _atuin_preexec --on-event fish_preexec
     set -gx ATUIN_HISTORY_ID (atuin history start "$argv[1]")

--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -1,6 +1,6 @@
 
-set -Gx ATUIN_SESSION (atuin uuid)
-set -Gx ATUIN_HISTORY (atuin history list)
+set -gx ATUIN_SESSION (atuin uuid)
+set -gx ATUIN_HISTORY (atuin history list)
 
 function _atuin_preexec --on-event fish_preexec
     set -gx ATUIN_HISTORY_ID (atuin history start "$argv[1]")

--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -22,7 +22,7 @@ function _atuin_search
 end
 
 if test -z $ATUIN_NOBIND
-	  bind -k up '_atuin_search'
-	  bind \eOA '_atuin_search'
-	  bind \e\[A '_atuin_search'
+    bind -k up '_atuin_search'
+    bind \eOA '_atuin_search'
+    bind \e\[A '_atuin_search'
 end

--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -1,0 +1,26 @@
+
+export ATUIN_SESSION=(atuin uuid)
+export ATUIN_HISTORY=(atuin history list)
+
+function _atuin_preexec --on-event fish_preexec
+    set -gx ATUIN_HISTORY_ID (atuin history start "$argv[1]")
+end
+
+function _atuin_postexec --on-event fish_postexec
+    set s $status
+    if test -n "$ATUIN_HISTORY_ID"
+        RUST_LOG=error atuin history end $ATUIN_HISTORY_ID --exit $s &; disown
+    end
+end
+
+function _atuin_search
+    set h (RUST_LOG=error atuin search -i (commandline -b) 3>&1 1>&2 2>&3)
+    commandline -f repaint
+    if test -n "$h"
+        commandline -r $h
+    end
+end
+
+bind -k up '_atuin_search'
+bind \eOA '_atuin_search'
+bind \e\[A '_atuin_search'


### PR DESCRIPTION
Closes #57

So, Fish YAML is not real YAML. So there's no point bringing out a YAML parser for this. Instead, we read line by line.

We use `- ` at the beginning to determine whether the line is a new entry. If we find a new entry line and we've found a `cmd: ...` value, we exit the loop and return our history item.

It's pretty fault tolerant, ignoring bad lines and missing values.