### PR TITLE
Enable help messages for command line arguments

### DIFF
--- a/src/command/history.rs
+++ b/src/command/history.rs
@@ -43,7 +43,7 @@ pub enum Cmd {
         #[structopt(long, short)]
         human: bool,
 
-        #[structopt(long, about = "Show only the text of the command")]
+        #[structopt(long, help = "Show only the text of the command")]
         cmd_only: bool,
     },
 
@@ -55,7 +55,7 @@ pub enum Cmd {
         #[structopt(long, short)]
         human: bool,
 
-        #[structopt(long, about = "Show only the text of the command")]
+        #[structopt(long, help = "Show only the text of the command")]
         cmd_only: bool,
     },
 }

--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -18,7 +18,7 @@ pub struct Cmd {
     #[structopt(long, short)]
     pub password: Option<String>,
 
-    #[structopt(long, short, about = "the encryption key for your account")]
+    #[structopt(long, short, help = "the encryption key for your account")]
     pub key: Option<String>,
 }
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -46,39 +46,39 @@ pub enum AtuinCmd {
 
     #[structopt(about = "interactive history search")]
     Search {
-        #[structopt(long, short, about = "filter search result by directory")]
+        #[structopt(long, short, help = "filter search result by directory")]
         cwd: Option<String>,
 
-        #[structopt(long = "exclude-cwd", about = "exclude directory from results")]
+        #[structopt(long = "exclude-cwd", help = "exclude directory from results")]
         exclude_cwd: Option<String>,
 
-        #[structopt(long, short, about = "filter search result by exit code")]
+        #[structopt(long, short, help = "filter search result by exit code")]
         exit: Option<i64>,
 
-        #[structopt(long = "exclude-exit", about = "exclude results with this exit code")]
+        #[structopt(long = "exclude-exit", help = "exclude results with this exit code")]
         exclude_exit: Option<i64>,
 
-        #[structopt(long, short, about = "only include results added before this date")]
+        #[structopt(long, short, help = "only include results added before this date")]
         before: Option<String>,
 
-        #[structopt(long, about = "only include results after this date")]
+        #[structopt(long, help = "only include results after this date")]
         after: Option<String>,
 
-        #[structopt(long, short, about = "open interactive search UI")]
+        #[structopt(long, short, help = "open interactive search UI")]
         interactive: bool,
 
-        #[structopt(long, short, about = "use human-readable formatting for time")]
+        #[structopt(long, short, help = "use human-readable formatting for time")]
         human: bool,
 
         query: Vec<String>,
 
-        #[structopt(long, about = "Show only the text of the command")]
+        #[structopt(long, help = "Show only the text of the command")]
         cmd_only: bool,
     },
 
     #[structopt(about = "sync with the configured server")]
     Sync {
-        #[structopt(long, short, about = "force re-download everything")]
+        #[structopt(long, short, help = "force re-download everything")]
         force: bool,
     },
 

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -11,10 +11,10 @@ pub enum Cmd {
         aliases=&["s", "st", "sta", "star"],
     )]
     Start {
-        #[structopt(about = "specify the host address to bind", long, short)]
+        #[structopt(help = "specify the host address to bind", long, short)]
         host: Option<String>,
 
-        #[structopt(about = "specify the port to bind", long, short)]
+        #[structopt(help = "specify the port to bind", long, short)]
         port: Option<u16>,
     },
 }


### PR DESCRIPTION
While working on #235, I realized that help messages for command line arguments are not shown.

```
$ atuin search --help

...
FLAGS:
    -i, --interactive    
    -h, --human          
        --cmd-only       
        --help           Prints help information
    -V, --version        Prints version information

OPTIONS:
    -c, --cwd <cwd>                      
        --exclude-cwd <exclude-cwd>      
    -e, --exit <exit>                    
        --exclude-exit <exclude-exit>    
    -b, --before <before>                
        --after <after>                  
...
```

According to [structopt docs](https://docs.rs/structopt/0.3.25/structopt/index.html#help-messages), `help=` option should used for arguments whereas `about=` is used for subcommands. In Atuin, `about=` is used for both values.

In this PR, I've used `help=` option for arguments thus made the help messages visible on the command line:


```
$ atuin search --help

...
FLAGS:
    -i, --interactive    open interactive search UI
    -h, --human          use human-readable formatting for time
        --cmd-only       Show only the text of the command
        --help           Prints help information
    -V, --version        Prints version information

OPTIONS:
    -c, --cwd <cwd>                      filter search result by directory
        --exclude-cwd <exclude-cwd>      exclude directory from results
    -e, --exit <exit>                    filter search result by exit code
        --exclude-exit <exclude-exit>    exclude results with this exit code
    -b, --before <before>                only include results added before this date
        --after <after>                  only include results after this date
...
```

