### PR TITLE
remove unused environment var loading entire history into an env var

### DIFF
--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -1,6 +1,4 @@
-
 set -gx ATUIN_SESSION (atuin uuid)
-set -gx ATUIN_HISTORY (atuin history list)
 
 function _atuin_preexec --on-event fish_preexec
     set -gx ATUIN_HISTORY_ID (atuin history start "$argv[1]")
@@ -9,7 +7,8 @@ end
 function _atuin_postexec --on-event fish_postexec
     set s $status
     if test -n "$ATUIN_HISTORY_ID"
-        RUST_LOG=error atuin history end $ATUIN_HISTORY_ID --exit $s &; disown
+        RUST_LOG=error atuin history end $ATUIN_HISTORY_ID --exit $s &
+        disown
     end
 end
 
@@ -22,7 +21,7 @@ function _atuin_search
 end
 
 if test -z $ATUIN_NOBIND
-    bind -k up '_atuin_search'
-    bind \eOA '_atuin_search'
-    bind \e\[A '_atuin_search'
+    bind -k up _atuin_search
+    bind \eOA _atuin_search
+    bind \e\[A _atuin_search
 end


### PR DESCRIPTION
It seems that `ATUIN_HISTORY` environment variable isn't used anywhere, and defining it loads your entire history into an environment variable. If you history gets too big, you'll get an error that your argument list is larger than the OS limit. On macOS this is 1MB.

Fixes #241 