### PR TITLE
Add Alt+backspace and Ctrl+u keybinds for deleting by word and by line, respectively

### DIFF
--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -207,6 +207,23 @@ async fn key_handler(
             app.input.pop();
             query_results(app, search_mode, db).await.unwrap();
         }
+        // \u{7f} is escape sequence for backspace
+        Key::Alt('\u{7f}') => {
+            let words: Vec<&str> = app.input.split(' ').collect();
+            if words.is_empty() {
+                return None;
+            }
+            if words.len() == 1 {
+                app.input = String::from("");
+            } else {
+                app.input = words[0..(words.len() - 1)].join(" ");
+            }
+            query_results(app, search_mode, db).await.unwrap();
+        }
+        Key::Ctrl('u') => {
+            app.input = String::from("");
+            query_results(app, search_mode, db).await.unwrap();
+        }
         Key::Down | Key::Ctrl('n') => {
             let i = match app.results_state.selected() {
                 Some(i) => {

--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -1,6 +1,4 @@
-
 set -gx ATUIN_SESSION (atuin uuid)
-set -gx ATUIN_HISTORY (atuin history list)
 
 function _atuin_preexec --on-event fish_preexec
     set -gx ATUIN_HISTORY_ID (atuin history start "$argv[1]")
@@ -9,7 +7,8 @@ end
 function _atuin_postexec --on-event fish_postexec
     set s $status
     if test -n "$ATUIN_HISTORY_ID"
-        RUST_LOG=error atuin history end $ATUIN_HISTORY_ID --exit $s &; disown
+        RUST_LOG=error atuin history end $ATUIN_HISTORY_ID --exit $s &
+        disown
     end
 end
 
@@ -22,7 +21,7 @@ function _atuin_search
 end
 
 if test -z $ATUIN_NOBIND
-    bind -k up '_atuin_search'
-    bind \eOA '_atuin_search'
-    bind \e\[A '_atuin_search'
+    bind -k up _atuin_search
+    bind \eOA _atuin_search
+    bind \e\[A _atuin_search
 end


### PR DESCRIPTION
Fixes #227 

These are both standard shell key binds, so we should be able to use them at the Atuin prompt as well.