### PR TITLE
Do not crash if the history timestamp is in the future

### DIFF
--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -42,7 +42,16 @@ impl State {
                 let duration: Vec<&str> = duration.split(' ').collect();
 
                 let ago = chrono::Utc::now().sub(h.timestamp);
-                let ago = humantime::format_duration(ago.to_std().unwrap()).to_string();
+
+                // Account for the chance that h.timestamp is "in the future"
+                // This would mean that "ago" is negative, and the unwrap here
+                // would fail.
+                // If the timestamp would otherwise be in the future, display
+                // the time ago as 0.
+                let ago = humantime::format_duration(
+                    ago.to_std().unwrap_or_else(|_| Duration::new(0, 0)),
+                )
+                .to_string();
                 let ago: Vec<&str> = ago.split(' ').collect();
 
                 (


### PR DESCRIPTION
Resolve #189

We were throwing an OutOfRangeError. This occurs when you attempt to
convert to a duration, and your input is <0. A value in the future would
have done this. This is especially noticeable during DST...