### PR TITLE
Update fish bindings.

### DIFF
--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -21,7 +21,15 @@ function _atuin_search
 end
 
 if test -z $ATUIN_NOBIND
+    bind \cr _atuin_search
     bind -k up _atuin_search
     bind \eOA _atuin_search
     bind \e\[A _atuin_search
+
+    if bind -M insert > /dev/null 2>&1
+        bind -M insert \cr _atuin_search
+        bind -M insert -k up _atuin_search
+        bind -M insert \eOA _atuin_search
+        bind -M insert \e\[A _atuin_search
+    end
 end


### PR DESCRIPTION
This change adds a binding for `Ctrl+r` and sets all the bindings to apply in both the `default` and `insert` modes (if it exists). The `insert` mode allows the keybindings to function as expected for users that use the vim keybindings in fish shell, which is quite common.

This matches the [behavior of fzf](https://github.com/junegunn/fzf/blob/205f885d6941eac47004779d9125df1463458fdd/shell/key-bindings.fish#L113-L121).