### PR TITLE
Restore bash 4.2 compatibility, only add hook once

### DIFF
--- a/src/shell/atuin.bash
+++ b/src/shell/atuin.bash
@@ -26,9 +26,9 @@ __atuin_history ()
 }
 
 
-if [[ -v BLE_VERSION ]]; then
-    blehook PRECMD+=_atuin_precmd
-    blehook PREEXEC+=_atuin_preexec
+if [[ -n "${BLE_VERSION-}" ]]; then
+    blehook PRECMD-+=_atuin_precmd
+    blehook PREEXEC-+=_atuin_preexec
 else
     precmd_functions+=(_atuin_precmd)
     preexec_functions+=(_atuin_preexec)


### PR DESCRIPTION
Based on https://github.com/wez/wezterm/commit/78ea214a96da7e9e8c8e5f3539bb788902eaff53 abd https://github.com/wez/wezterm/pull/1586/files#diff-ed9ac6e03535303bbfcddf25ca962776c502e1d0218946d7cc96319d142064a0R446-R449