### PR TITLE
Fix `history list --cwd` errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,6 @@ dependencies = [
  "crossbeam-channel",
  "directories",
  "eyre",
- "fork",
  "humantime 2.1.0",
  "indicatif",
  "itertools",
@@ -112,9 +111,6 @@ dependencies = [
  "config",
  "directories",
  "eyre",
- "fern",
- "humantime 2.1.0",
- "indicatif",
  "itertools",
  "log",
  "minspan",
@@ -140,8 +136,6 @@ name = "atuin-common"
 version = "0.8.0"
 dependencies = [
  "chrono",
- "eyre",
- "rmp-serde",
  "rust-crypto",
  "serde 1.0.132",
  "serde_derive",
@@ -159,17 +153,10 @@ dependencies = [
  "atuin-common",
  "base64",
  "chrono",
- "chrono-english",
  "config",
- "directories",
  "eyre",
- "fern",
- "fork",
- "indicatif",
  "log",
- "parse_duration",
  "rand 0.8.4",
- "rmp-serde",
  "rust-crypto",
  "serde 1.0.132",
  "serde_derive",
@@ -177,8 +164,6 @@ dependencies = [
  "sodiumoxide",
  "sqlx",
  "tokio",
- "unicode-width",
- "urlencoding",
  "uuid",
  "warp",
  "whoami",
@@ -329,17 +314,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "colored"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
 ]
 
 [[package]]
@@ -576,29 +550,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fern"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
-dependencies = [
- "colored",
- "log",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "fork"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c5b9b0bce249a456f83ac4404e8baad0d2ba81cf651949719a4f74eb7323bb"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "form_urlencoded"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tui = "0.16"
 termion = "1.5"
 unicode-width = "0.1"
 itertools = "0.10.3"
-fork = "0.1.18"
+# fork = "0.1.18"
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1.49"
 chrono-english = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ tui = "0.16"
 termion = "1.5"
 unicode-width = "0.1"
 itertools = "0.10.3"
-# fork = "0.1.18"
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1.49"
 chrono-english = "0.1.4"

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -14,12 +14,10 @@ repository = "https://github.com/ellie/atuin"
 atuin-common = { path = "../atuin-common", version = "0.8.0" }
 
 log = "0.4"
-fern = {version = "0.6.0", features = ["colored"] }
 chrono = { version = "0.4", features = ["serde"] }
 eyre = "0.6"
 directories = "3"
 uuid = { version = "0.8", features = ["v4"] }
-indicatif = "0.16.2"
 whoami = "1.1.2"
 chrono-english = "0.1.4"
 config = "0.11"
@@ -28,7 +26,11 @@ serde = "1.0.126"
 serde_json = "1.0.75"
 rmp-serde = "0.15.5"
 sodiumoxide = "0.2.6"
-reqwest = { version = "0.11", features = ["blocking", "json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.11", features = [
+  "blocking",
+  "json",
+  "rustls-tls",
+], default-features = false }
 base64 = "0.13.0"
 parse_duration = "2.1.1"
 rand = "0.8.4"
@@ -36,8 +38,16 @@ rust-crypto = "^0.2"
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1.49"
 urlencoding = "1.3.3"
-humantime = "2.1.0"
 itertools = "0.10.3"
 shellexpand = "2"
-sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "uuid", "chrono", "sqlite" ] }
+sqlx = { version = "0.5", features = [
+  "runtime-tokio-rustls",
+  "uuid",
+  "chrono",
+  "sqlite",
+] }
 minspan = "0.1.1"
+
+# humantime = "2.1.0"
+# fern = { version = "0.6.0", features = ["colored"] }
+# indicatif = "0.16.2"

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -47,7 +47,3 @@ sqlx = { version = "0.5", features = [
   "sqlite",
 ] }
 minspan = "0.1.1"
-
-# humantime = "2.1.0"
-# fern = { version = "0.6.0", features = ["colored"] }
-# indicatif = "0.16.2"

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -283,7 +283,7 @@ impl Database for Sqlite {
         query: &str,
     ) -> Result<Vec<History>> {
         let orig_query = query;
-        let query = query.to_string().replace("*", "%"); // allow wildcard char
+        let query = query.to_string().replace('*', "%"); // allow wildcard char
         let limit = limit.map_or("".to_owned(), |l| format!("limit {}", l));
 
         let query = match search_mode {

--- a/atuin-common/Cargo.toml
+++ b/atuin-common/Cargo.toml
@@ -19,6 +19,3 @@ serde = "1.0.126"
 serde_json = "1.0.75"
 warp = "0.3"
 uuid = { version = "0.8", features = ["v4"] }
-
-# eyre = "0.6"
-# rmp-serde = "0.15.5"

--- a/atuin-common/Cargo.toml
+++ b/atuin-common/Cargo.toml
@@ -14,10 +14,11 @@ repository = "https://github.com/ellie/atuin"
 rust-crypto = "^0.2"
 sodiumoxide = "0.2.6"
 chrono = { version = "0.4", features = ["serde"] }
-eyre = "0.6"
 serde_derive = "1.0.125"
 serde = "1.0.126"
 serde_json = "1.0.75"
-rmp-serde = "0.15.5"
 warp = "0.3"
 uuid = { version = "0.8", features = ["v4"] }
+
+# eyre = "0.6"
+# rmp-serde = "0.15.5"

--- a/atuin-server/Cargo.toml
+++ b/atuin-server/Cargo.toml
@@ -28,13 +28,3 @@ tokio = { version = "1", features = ["full"] }
 warp = "0.3"
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "uuid", "chrono", "postgres" ] }
 async-trait = "0.1.49"
-
-# urlencoding = "1.3.3"
-# unicode-width = "0.1"
-# rmp-serde = "0.15.5"
-# parse_duration = "2.1.1"
-# indicatif = "0.16.2"
-# fork = "0.1.18"
-# fern = {version = "0.6.0", features = ["colored"] }
-# directories = "3"
-# chrono-english = "0.1.4"

--- a/atuin-server/Cargo.toml
+++ b/atuin-server/Cargo.toml
@@ -12,28 +12,29 @@ repository = "https://github.com/ellie/atuin"
 atuin-common = { path = "../atuin-common", version = "0.8.0" }
 
 log = "0.4"
-fern = {version = "0.6.0", features = ["colored"] }
 chrono = { version = "0.4", features = ["serde"] }
 eyre = "0.6"
-directories = "3"
 uuid = { version = "0.8", features = ["v4"] }
-indicatif = "0.16.2"
 whoami = "1.1.2"
-chrono-english = "0.1.4"
 config = "0.11"
 serde_derive = "1.0.125"
 serde = "1.0.126"
 serde_json = "1.0.75"
-rmp-serde = "0.15.5"
-unicode-width = "0.1"
 sodiumoxide = "0.2.6"
 base64 = "0.13.0"
-fork = "0.1.18"
-parse_duration = "2.1.1"
 rand = "0.8.4"
 rust-crypto = "^0.2"
 tokio = { version = "1", features = ["full"] }
 warp = "0.3"
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "uuid", "chrono", "postgres" ] }
 async-trait = "0.1.49"
-urlencoding = "1.3.3"
+
+# urlencoding = "1.3.3"
+# unicode-width = "0.1"
+# rmp-serde = "0.15.5"
+# parse_duration = "2.1.1"
+# indicatif = "0.16.2"
+# fork = "0.1.18"
+# fern = {version = "0.6.0", features = ["colored"] }
+# directories = "3"
+# chrono-english = "0.1.4"

--- a/atuin-server/src/router.rs
+++ b/atuin-server/src/router.rs
@@ -23,7 +23,9 @@ fn with_db(
     warp::any().map(move || db.clone())
 }
 
-fn with_user(postgres: Postgres) -> impl Filter<Extract = (User,), Error = warp::Rejection> + Clone {
+fn with_user(
+    postgres: Postgres,
+) -> impl Filter<Extract = (User,), Error = warp::Rejection> + Clone {
     warp::header::<String>("authorization").and_then(move |header: String| {
         // async closures are still buggy :(
         let postgres = postgres.clone();

--- a/atuin-server/src/router.rs
+++ b/atuin-server/src/router.rs
@@ -5,10 +5,11 @@ use warp::{hyper::StatusCode, Filter};
 
 use atuin_common::api::SyncHistoryRequest;
 
-use super::handlers;
-use super::{database::Database, database::Postgres};
-use crate::models::User;
-use crate::settings::Settings;
+use super::{
+    database::{Database, Postgres},
+    handlers,
+};
+use crate::{models::User, settings::Settings};
 
 fn with_settings(
     settings: Settings,
@@ -22,9 +23,7 @@ fn with_db(
     warp::any().map(move || db.clone())
 }
 
-fn with_user(
-    postgres: Postgres,
-) -> impl Filter<Extract = (User,), Error = warp::Rejection> + Clone {
+fn with_user(postgres: Postgres) -> impl Filter<Extract = (User,), Error = warp::Rejection> + Clone {
     warp::header::<String>("authorization").and_then(move |header: String| {
         // async closures are still buggy :(
         let postgres = postgres.clone();
@@ -32,17 +31,15 @@ fn with_user(
         async move {
             let header: Vec<&str> = header.split(' ').collect();
 
-            let token;
-
-            if header.len() == 2 {
+            let token = if header.len() == 2 {
                 if header[0] != "Token" {
                     return Err(warp::reject());
                 }
 
-                token = header[1];
+                header[1]
             } else {
                 return Err(warp::reject());
-            }
+            };
 
             let user = postgres
                 .get_session_user(token)

--- a/atuin.plugin.zsh
+++ b/atuin.plugin.zsh
@@ -1,6 +1,10 @@
 # shellcheck disable=2148,SC2168,SC1090,SC2125
-local FOUND_ATUIN=$+commands[atuin]
 
-if [[ $FOUND_ATUIN -eq 1 ]]; then
-  source <(atuin init zsh)
-fi
+# Set $0
+# reference: https://zdharma-continuum.github.io/zinit/wiki/zsh-plugin-standard/
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
+zmodload -Fa zsh/parameter p:commands
+
+(( $+commands[atuin] )) && eval "$(atuin init zsh)"

--- a/atuin.plugin.zsh
+++ b/atuin.plugin.zsh
@@ -1,10 +1,6 @@
 # shellcheck disable=2148,SC2168,SC1090,SC2125
+local FOUND_ATUIN=$+commands[atuin]
 
-# Set $0
-# reference: https://zdharma-continuum.github.io/zinit/wiki/zsh-plugin-standard/
-0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
-0="${${(M)0:#/*}:-$PWD/$0}"
-
-zmodload -Fa zsh/parameter p:commands
-
-(( $+commands[atuin] )) && eval "$(atuin init zsh)"
+if [[ $FOUND_ATUIN -eq 1 ]]; then
+  source <(atuin init zsh)
+fi

--- a/src/command/history.rs
+++ b/src/command/history.rs
@@ -174,7 +174,7 @@ impl Cmd {
                 let history = match (session, cwd) {
                     (None, None) => db.list(None, false).await?,
                     (None, Some(cwd)) => {
-                        let query = format!("select * from history where cwd = {};", cwd);
+                        let query = format!("select * from history where cwd = '{}';", cwd);
                         db.query_history(&query).await?
                     }
                     (Some(session), None) => {
@@ -183,7 +183,7 @@ impl Cmd {
                     }
                     (Some(session), Some(cwd)) => {
                         let query = format!(
-                            "select * from history where cwd = {} and session = {};",
+                            "select * from history where cwd = '{}' and session = {};",
                             cwd, session
                         );
                         db.query_history(&query).await?

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -1,7 +1,6 @@
 use chrono::Utc;
 use eyre::Result;
-use std::time::Duration;
-use std::{io::stdout, ops::Sub};
+use std::{io::stdout, ops::Sub, time::Duration};
 
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
@@ -10,13 +9,16 @@ use tui::{
     style::{Color, Modifier, Style},
     text::{Span, Spans, Text},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
-    Frame, Terminal,
+    Frame,
+    Terminal,
 };
 use unicode_width::UnicodeWidthStr;
 
-use atuin_client::database::Database;
-use atuin_client::history::History;
-use atuin_client::settings::{SearchMode, Settings};
+use atuin_client::{
+    database::Database,
+    history::History,
+    settings::{SearchMode, Settings},
+};
 
 use crate::command::event::{Event, Events};
 
@@ -36,8 +38,7 @@ impl State {
         self.results
             .iter()
             .map(|h| {
-                let duration =
-                    Duration::from_millis(std::cmp::max(h.duration, 0) as u64 / 1_000_000);
+                let duration = Duration::from_millis(std::cmp::max(h.duration, 0) as u64 / 1_000_000);
                 let duration = humantime::format_duration(duration).to_string();
                 let duration: Vec<&str> = duration.split(' ').collect();
 
@@ -48,10 +49,9 @@ impl State {
                 // would fail.
                 // If the timestamp would otherwise be in the future, display
                 // the time ago as 0.
-                let ago = humantime::format_duration(
-                    ago.to_std().unwrap_or_else(|_| Duration::new(0, 0)),
-                )
-                .to_string();
+                let ago =
+                    humantime::format_duration(ago.to_std().unwrap_or_else(|_| Duration::new(0, 0)))
+                        .to_string();
                 let ago: Vec<&str> = ago.split(' ').collect();
 
                 (
@@ -96,7 +96,7 @@ impl State {
             .iter()
             .enumerate()
             .map(|(i, m)| {
-                let command = m.command.to_string().replace("\n", " ").replace("\t", " ");
+                let command = m.command.to_string().replace('\n', " ").replace('\t', " ");
 
                 let mut command = Span::raw(command);
 
@@ -110,13 +110,12 @@ impl State {
                     None => Span::raw("   "),
                     Some(selected) => match i.checked_sub(selected) {
                         None => Span::raw("   "),
-                        Some(diff) => {
+                        Some(diff) =>
                             if 0 < diff && diff < 10 {
                                 Span::raw(format!(" {} ", diff))
                             } else {
                                 Span::raw("   ")
-                            }
-                        }
+                            },
                     },
                 };
 
@@ -133,8 +132,7 @@ impl State {
 
                 if let Some(selected) = self.results_state.selected() {
                     if selected == i {
-                        command.style =
-                            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD);
+                        command.style = Style::default().fg(Color::Red).add_modifier(Modifier::BOLD);
                     }
                 }
 
@@ -197,7 +195,7 @@ async fn key_handler(
                     .get(i)
                     .map_or(app.input.clone(), |h| h.command.clone()),
             );
-        }
+        },
         Key::Alt(c) if ('1'..='9').contains(&c) => {
             let c = c.to_digit(10)? as usize;
             let i = app.results_state.selected()? + c;
@@ -207,15 +205,15 @@ async fn key_handler(
                     .get(i)
                     .map_or(app.input.clone(), |h| h.command.clone()),
             );
-        }
+        },
         Key::Char(c) => {
             app.input.push(c);
             query_results(app, search_mode, db).await.unwrap();
-        }
+        },
         Key::Backspace => {
             app.input.pop();
             query_results(app, search_mode, db).await.unwrap();
-        }
+        },
         // \u{7f} is escape sequence for backspace
         Key::Alt('\u{7f}') => {
             let words: Vec<&str> = app.input.split(' ').collect();
@@ -228,38 +226,36 @@ async fn key_handler(
                 app.input = words[0..(words.len() - 1)].join(" ");
             }
             query_results(app, search_mode, db).await.unwrap();
-        }
+        },
         Key::Ctrl('u') => {
             app.input = String::from("");
             query_results(app, search_mode, db).await.unwrap();
-        }
+        },
         Key::Down | Key::Ctrl('n') => {
             let i = match app.results_state.selected() {
-                Some(i) => {
+                Some(i) =>
                     if i == 0 {
                         0
                     } else {
                         i - 1
-                    }
-                }
+                    },
                 None => 0,
             };
             app.results_state.select(Some(i));
-        }
+        },
         Key::Up | Key::Ctrl('p') => {
             let i = match app.results_state.selected() {
-                Some(i) => {
+                Some(i) =>
                     if i >= app.results.len() - 1 {
                         app.results.len() - 1
                     } else {
                         i + 1
-                    }
-                }
+                    },
                 None => 0,
             };
             app.results_state.select(Some(i));
-        }
-        _ => {}
+        },
+        _ => {},
     };
 
     None
@@ -352,8 +348,8 @@ async fn select_history(
     let events = Events::new();
 
     let mut app = State {
-        input: query.join(" "),
-        results: Vec::new(),
+        input:         query.join(" "),
+        results:       Vec::new(),
         results_state: ListState::default(),
     };
 

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -9,8 +9,7 @@ use tui::{
     style::{Color, Modifier, Style},
     text::{Span, Spans, Text},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
-    Frame,
-    Terminal,
+    Frame, Terminal,
 };
 use unicode_width::UnicodeWidthStr;
 
@@ -38,7 +37,8 @@ impl State {
         self.results
             .iter()
             .map(|h| {
-                let duration = Duration::from_millis(std::cmp::max(h.duration, 0) as u64 / 1_000_000);
+                let duration =
+                    Duration::from_millis(std::cmp::max(h.duration, 0) as u64 / 1_000_000);
                 let duration = humantime::format_duration(duration).to_string();
                 let duration: Vec<&str> = duration.split(' ').collect();
 
@@ -49,9 +49,10 @@ impl State {
                 // would fail.
                 // If the timestamp would otherwise be in the future, display
                 // the time ago as 0.
-                let ago =
-                    humantime::format_duration(ago.to_std().unwrap_or_else(|_| Duration::new(0, 0)))
-                        .to_string();
+                let ago = humantime::format_duration(
+                    ago.to_std().unwrap_or_else(|_| Duration::new(0, 0)),
+                )
+                .to_string();
                 let ago: Vec<&str> = ago.split(' ').collect();
 
                 (
@@ -110,12 +111,13 @@ impl State {
                     None => Span::raw("   "),
                     Some(selected) => match i.checked_sub(selected) {
                         None => Span::raw("   "),
-                        Some(diff) =>
+                        Some(diff) => {
                             if 0 < diff && diff < 10 {
                                 Span::raw(format!(" {} ", diff))
                             } else {
                                 Span::raw("   ")
-                            },
+                            }
+                        }
                     },
                 };
 
@@ -132,7 +134,8 @@ impl State {
 
                 if let Some(selected) = self.results_state.selected() {
                     if selected == i {
-                        command.style = Style::default().fg(Color::Red).add_modifier(Modifier::BOLD);
+                        command.style =
+                            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD);
                     }
                 }
 
@@ -195,7 +198,7 @@ async fn key_handler(
                     .get(i)
                     .map_or(app.input.clone(), |h| h.command.clone()),
             );
-        },
+        }
         Key::Alt(c) if ('1'..='9').contains(&c) => {
             let c = c.to_digit(10)? as usize;
             let i = app.results_state.selected()? + c;
@@ -205,15 +208,15 @@ async fn key_handler(
                     .get(i)
                     .map_or(app.input.clone(), |h| h.command.clone()),
             );
-        },
+        }
         Key::Char(c) => {
             app.input.push(c);
             query_results(app, search_mode, db).await.unwrap();
-        },
+        }
         Key::Backspace => {
             app.input.pop();
             query_results(app, search_mode, db).await.unwrap();
-        },
+        }
         // \u{7f} is escape sequence for backspace
         Key::Alt('\u{7f}') => {
             let words: Vec<&str> = app.input.split(' ').collect();
@@ -226,36 +229,38 @@ async fn key_handler(
                 app.input = words[0..(words.len() - 1)].join(" ");
             }
             query_results(app, search_mode, db).await.unwrap();
-        },
+        }
         Key::Ctrl('u') => {
             app.input = String::from("");
             query_results(app, search_mode, db).await.unwrap();
-        },
+        }
         Key::Down | Key::Ctrl('n') => {
             let i = match app.results_state.selected() {
-                Some(i) =>
+                Some(i) => {
                     if i == 0 {
                         0
                     } else {
                         i - 1
-                    },
+                    }
+                }
                 None => 0,
             };
             app.results_state.select(Some(i));
-        },
+        }
         Key::Up | Key::Ctrl('p') => {
             let i = match app.results_state.selected() {
-                Some(i) =>
+                Some(i) => {
                     if i >= app.results.len() - 1 {
                         app.results.len() - 1
                     } else {
                         i + 1
-                    },
+                    }
+                }
                 None => 0,
             };
             app.results_state.select(Some(i));
-        },
-        _ => {},
+        }
+        _ => {}
     };
 
     None
@@ -348,8 +353,8 @@ async fn select_history(
     let events = Events::new();
 
     let mut app = State {
-        input:         query.join(" "),
-        results:       Vec::new(),
+        input: query.join(" "),
+        results: Vec::new(),
         results_state: ListState::default(),
     };
 


### PR DESCRIPTION
#### Before the fix

```bash
$ atuin history list --cwd

Error: error returned from database: near "/": syntax error

Caused by:
    near "/": syntax error

Location:
    atuin-client/src/database.rs:316:19
```

1. The query into the database was not quoting the path. This fixes that issue.
2. Unused dependencies are removed:

```
atuin
    - fork

atuin-client
    - fern
    - humantime
    - indicatif

atuin-common
    - eyre
    - rmp-serde

atuin-sever
    - chrono-english
    - directories
    - fern
    - fork
    - indicatif
    - parse_duration
    - rmp-serde
    - unicode-width
    - urlencoding
```


3. I fixed the `zsh` plugin by standardizing it according to `zdharma`. The reference can be found in the file. It results in the following:

```zsh
0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
0="${${(M)0:#/*}:-$PWD/$0}"
```

The `$commands` array is also loaded with `zmodload` in case the user doesn't have it loaded for whatever reason