### PR TITLE
Add rust-version to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "atuin"
 version = "0.8.0"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 edition = "2018"
+rust-version = "1.59"
 license = "MIT"
 description = "atuin - magical shell history"
 homepage = "https://atuin.sh"


### PR DESCRIPTION
This adds `rust-version = "1.59"` to `Cargo.toml` to indicate the minimum required version.

I tried compiling with rust 1.56 and got a bunch of compiler errors due to tuple destructuring being used, which apparently [requires rust 1.59](https://github.com/rust-lang/rust/commit/d258e92900739e7798ed4fccfbbb8cb0fe519acd). With this parameter new contributors should get a much more helpful error.