### PR TITLE
Add compact mode

### DIFF
--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -41,9 +41,22 @@ impl From<Dialect> for chrono_english::Dialect {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Copy)]
+pub enum Style {
+    #[serde(rename = "auto")]
+    Auto,
+
+    #[serde(rename = "full")]
+    Full,
+
+    #[serde(rename = "compact")]
+    Compact,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct Settings {
     pub dialect: Dialect,
+    pub style: Style,
     pub auto_sync: bool,
     pub sync_address: String,
     pub sync_frequency: String,
@@ -134,6 +147,7 @@ impl Settings {
             .set_default("sync_address", "https://api.atuin.sh")?
             .set_default("search_mode", "prefix")?
             .set_default("session_token", "")?
+            .set_default("style", "auto")?
             .add_source(Environment::with_prefix("atuin").separator("_"));
 
         config_builder = if config_file.exists() {


### PR DESCRIPTION
Using this for a while I frequently ran into issues when the terminal was pretty slim, e.g. at the bottom of an IDE. So I've created a compact mode that saves 8 lines of precious terminal space.

I've added a new config option that allows to switch the style between `full`(the 'old' style), `compact` (the new one added in this PR) and `auto`, which toggles the `compact` style at a height of 14 lines (at 14 lines there are still 5 entries visible with `full` style). `auto` is used by default.

`compact` style
![image](https://user-images.githubusercontent.com/1710904/161623659-4fec047f-ea4b-471c-9581-861d2eb701a9.png)

`full` style with my VS Code terminal for color reference.
![image](https://user-images.githubusercontent.com/1710904/161623547-42afbfa7-a3ef-4820-bacd-fcaf1e324969.png)
