### PR TITLE
Update to clap 3.1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,15 +29,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +70,8 @@ dependencies = [
  "base64",
  "chrono",
  "chrono-english",
+ "clap",
+ "clap_complete",
  "cli-table",
  "crossbeam-channel",
  "directories",
@@ -91,7 +84,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "structopt",
  "tabwriter",
  "termion",
  "tokio",
@@ -317,17 +309,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_complete"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df6f3613c0a3cddfd78b41b10203eb322cb29b600cbdf808a7d3db95691b8e25"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -865,6 +881,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1393,15 @@ checksum = "1c672c7ad9ec066e428c00eb917124a06f08db19e2584de982cc34b1f4c12485"
 dependencies = [
  "dlv-list",
  "hashbrown 0.9.1",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2189,7 +2220,7 @@ checksum = "eee35713129561f5e55c554bba1c378e2a7e67f81257b7311183de98c50e6f94"
 dependencies = [
  "dotenv",
  "either",
- "heck",
+ "heck 0.3.3",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -2223,33 +2254,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -2324,12 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -2654,12 +2658,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ log = "0.4"
 pretty_env_logger = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 eyre = "0.6"
-structopt = "0.3"
 directories = "3"
 indicatif = "0.16.2"
 serde_derive = "1.0.125"
@@ -56,6 +55,8 @@ base64 = "0.13.0"
 humantime = "2.1.0"
 tabwriter = "1.2.1"
 crossbeam-channel = "0.5.1"
+clap = { version = "3.1.8", features = ["derive"] }
+clap_complete = "3.1.1"
 
 [profile.release]
 lto = "fat"

--- a/src/command/history.rs
+++ b/src/command/history.rs
@@ -2,8 +2,8 @@ use std::env;
 use std::io::Write;
 use std::time::Duration;
 
+use clap::Subcommand;
 use eyre::Result;
-use structopt::StructOpt;
 use tabwriter::TabWriter;
 
 use atuin_client::database::Database;
@@ -11,51 +11,42 @@ use atuin_client::history::History;
 use atuin_client::settings::Settings;
 use atuin_client::sync;
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
+#[clap(infer_subcommands = true)]
 pub enum Cmd {
-    #[structopt(
-        about="begins a new command in the history",
-        aliases=&["s", "st", "sta", "star"],
-    )]
+    /// Begins a new command in the history
     Start { command: Vec<String> },
 
-    #[structopt(
-        about="finishes a new command in the history (adds time, exit code)",
-        aliases=&["e", "en"],
-    )]
+    /// Finishes a new command in the history (adds time, exit code)
     End {
         id: String,
-        #[structopt(long, short)]
+        #[clap(long, short)]
         exit: i64,
     },
 
-    #[structopt(
-        about="list all items in history",
-        aliases=&["l", "li", "lis"],
-    )]
+    /// List all items in history
     List {
-        #[structopt(long, short)]
+        #[clap(long, short)]
         cwd: bool,
 
-        #[structopt(long, short)]
+        #[clap(long, short)]
         session: bool,
 
-        #[structopt(long, short)]
+        #[clap(long)]
         human: bool,
 
-        #[structopt(long, help = "Show only the text of the command")]
+        /// Show only the text of the command
+        #[clap(long)]
         cmd_only: bool,
     },
 
-    #[structopt(
-        about="get the last command ran",
-        aliases=&["la", "las"],
-    )]
+    /// Get the last command ran
     Last {
-        #[structopt(long, short)]
+        #[clap(long)]
         human: bool,
 
-        #[structopt(long, help = "Show only the text of the command")]
+        /// Show only the text of the command
+        #[clap(long)]
         cmd_only: bool,
     },
 }

--- a/src/command/import.rs
+++ b/src/command/import.rs
@@ -1,44 +1,30 @@
 use std::{env, path::PathBuf};
 
 use atuin_client::import::fish::Fish;
+use clap::Parser;
 use eyre::{eyre, Result};
-use structopt::StructOpt;
 
 use atuin_client::import::{bash::Bash, zsh::Zsh};
 use atuin_client::{database::Database, import::Importer};
 use atuin_client::{history::History, import::resh::Resh};
 use indicatif::ProgressBar;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
+#[clap(infer_subcommands = true)]
 pub enum Cmd {
-    #[structopt(
-        about="import history for the current shell",
-        aliases=&["a", "au", "aut"],
-    )]
+    /// Import history for the current shell
     Auto,
 
-    #[structopt(
-        about="import history from the zsh history file",
-        aliases=&["z", "zs"],
-    )]
+    /// Import history from the zsh history file
     Zsh,
 
-    #[structopt(
-        about="import history from the bash history file",
-        aliases=&["b", "ba", "bas"],
-    )]
+    /// Import history from the bash history file
     Bash,
 
-    #[structopt(
-        about="import history from the resh history file",
-        aliases=&["r", "re", "res"],
-    )]
+    /// Import history from the resh history file
     Resh,
 
-    #[structopt(
-        about="import history from the fish history file",
-        aliases=&["f", "fi", "fis"],
-    )]
+    /// Import history from the fish history file
     Fish,
 }
 

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -1,12 +1,12 @@
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub enum Cmd {
-    #[structopt(about = "zsh setup")]
+    /// Zsh setup
     Zsh,
-    #[structopt(about = "bash setup")]
+    /// Bash setup
     Bash,
-    #[structopt(about = "fish setup")]
+    /// Fish setup
     Fish,
 }
 

--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -2,23 +2,25 @@ use std::borrow::Cow;
 use std::io;
 
 use atuin_common::api::LoginRequest;
+use clap::AppSettings;
+use clap::Parser;
 use eyre::Result;
-use structopt::StructOpt;
 use tokio::{fs::File, io::AsyncWriteExt};
 
 use atuin_client::api_client;
 use atuin_client::settings::Settings;
 
-#[derive(StructOpt)]
-#[structopt(setting(structopt::clap::AppSettings::DeriveDisplayOrder))]
+#[derive(Parser)]
+#[clap(setting(AppSettings::DeriveDisplayOrder))]
 pub struct Cmd {
-    #[structopt(long, short)]
+    #[clap(long, short)]
     pub username: Option<String>,
 
-    #[structopt(long, short)]
+    #[clap(long, short)]
     pub password: Option<String>,
 
-    #[structopt(long, short, help = "the encryption key for your account")]
+    /// The encryption key for your account
+    #[clap(long, short)]
     pub key: Option<String>,
 }
 

--- a/src/command/register.rs
+++ b/src/command/register.rs
@@ -1,20 +1,21 @@
+use clap::AppSettings;
+use clap::Parser;
 use eyre::Result;
-use structopt::StructOpt;
 use tokio::{fs::File, io::AsyncWriteExt};
 
 use atuin_client::api_client;
 use atuin_client::settings::Settings;
 
-#[derive(StructOpt)]
-#[structopt(setting(structopt::clap::AppSettings::DeriveDisplayOrder))]
+#[derive(Parser)]
+#[clap(setting(AppSettings::DeriveDisplayOrder))]
 pub struct Cmd {
-    #[structopt(long, short)]
+    #[clap(long, short)]
     pub username: Option<String>,
 
-    #[structopt(long, short)]
+    #[clap(long, short)]
     pub email: Option<String>,
 
-    #[structopt(long, short)]
+    #[clap(long, short)]
     pub password: Option<String>,
 }
 

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1,20 +1,20 @@
+use clap::Parser;
 use eyre::Result;
-use structopt::StructOpt;
 
 use atuin_server::launch;
 use atuin_server::settings::Settings;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
+#[clap(infer_subcommands = true)]
 pub enum Cmd {
-    #[structopt(
-        about="starts the server",
-        aliases=&["s", "st", "sta", "star"],
-    )]
+    /// Start the server
     Start {
-        #[structopt(help = "specify the host address to bind", long, short)]
+        /// The host address to bind
+        #[clap(long, short)]
         host: Option<String>,
 
-        #[structopt(help = "specify the port to bind", long, short)]
+        /// The port to bind
+        #[clap(long, short)]
         port: Option<u16>,
     },
 }

--- a/src/command/stats.rs
+++ b/src/command/stats.rs
@@ -4,26 +4,21 @@ use chrono::prelude::*;
 use chrono::Duration;
 use chrono_english::parse_date_string;
 
+use clap::Parser;
 use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
 use eyre::{eyre, Result};
-use structopt::StructOpt;
 
 use atuin_client::database::Database;
 use atuin_client::history::History;
 use atuin_client::settings::Settings;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
+#[clap(infer_subcommands = true)]
 pub enum Cmd {
-    #[structopt(
-        about="compute statistics for all of time",
-        aliases=&["d", "da"],
-    )]
+    /// Compute statistics for all of time
     All,
 
-    #[structopt(
-        about="compute statistics for a single day",
-        aliases=&["d", "da"],
-    )]
+    /// Compute statistics for a single day
     Day { words: Vec<String> },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 #![warn(clippy::pedantic, clippy::nursery)]
 #![allow(clippy::use_self)] // not 100% reliable
 
+use clap::AppSettings;
+use clap::Parser;
 use eyre::Result;
-use structopt::{clap::AppSettings, StructOpt};
 
 #[macro_use]
 extern crate log;
@@ -13,15 +14,15 @@ mod command;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[derive(StructOpt)]
-#[structopt(
+/// Magical shell history
+#[derive(Parser)]
+#[clap(
     author = "Ellie Huxtable <e@elm.sh>",
     version = VERSION,
-    about = "Magical shell history",
-    global_settings(&[AppSettings::ColoredHelp, AppSettings::DeriveDisplayOrder])
+    global_setting(AppSettings::DeriveDisplayOrder),
 )]
 struct Atuin {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     atuin: AtuinCmd,
 }
 
@@ -35,5 +36,5 @@ impl Atuin {
 async fn main() -> Result<()> {
     pretty_env_logger::init();
 
-    Atuin::from_args().run().await
+    Atuin::parse().run().await
 }


### PR DESCRIPTION
Updated to use clap 3.1.x instead of structopt.