### PR TITLE
fix env config parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,12 +4,6 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
-
-[[package]]
-name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
@@ -371,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ad70579325f1a38ea4c13412b82241c5900700a69785d73e2736bd65a33f86"
+checksum = "a623a46970097d353e2c8154fa527d8ce45cd0e02cc1812969b889c49b3728e8"
 dependencies = [
  "async-trait",
  "json5",
@@ -577,12 +571,9 @@ dependencies = [
 
 [[package]]
 name = "dlv-list"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68df3f2b690c1b86e65ef7830956aededf3cb0a16f898f79b9a6f421a7b6211b"
-dependencies = [
- "rand 0.8.5",
-]
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "dotenv"
@@ -821,20 +812,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash 0.4.7",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -1388,12 +1379,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "ordered-multimap"
-version = "0.3.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c672c7ad9ec066e428c00eb917124a06f08db19e2584de982cc34b1f4c12485"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown 0.9.1",
+ "hashbrown 0.12.0",
 ]
 
 [[package]]
@@ -1865,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63471c4aa97a1cf8332a5f97709a79a4234698de6a1f5087faf66f2dae810e22"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
@@ -2164,7 +2155,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "195183bf6ff8328bb82c0511a83faf60aacf75840103388851db61d7a9854ae3"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
  "atoi",
  "base64",
  "bitflags",

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -20,7 +20,7 @@ directories = "3"
 uuid = { version = "0.8", features = ["v4"] }
 whoami = "1.1.2"
 chrono-english = "0.1.4"
-config = "0.12"
+config = "0.13"
 serde_derive = "1.0.125"
 serde = "1.0.126"
 serde_json = "1.0.75"

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -148,7 +148,11 @@ impl Settings {
             .set_default("search_mode", "prefix")?
             .set_default("session_token", "")?
             .set_default("style", "auto")?
-            .add_source(Environment::with_prefix("atuin").prefix_separator("_").separator("__"));
+            .add_source(
+                Environment::with_prefix("atuin")
+                    .prefix_separator("_")
+                    .separator("__"),
+            );
 
         config_builder = if config_file.exists() {
             config_builder.add_source(ConfigFile::new(

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -148,7 +148,7 @@ impl Settings {
             .set_default("search_mode", "prefix")?
             .set_default("session_token", "")?
             .set_default("style", "auto")?
-            .add_source(Environment::with_prefix("atuin").separator("_"));
+            .add_source(Environment::with_prefix("atuin").prefix_separator("_").separator("__"));
 
         config_builder = if config_file.exists() {
             config_builder.add_source(ConfigFile::new(

--- a/atuin-server/Cargo.toml
+++ b/atuin-server/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4", features = ["serde"] }
 eyre = "0.6"
 uuid = { version = "0.8", features = ["v4"] }
 whoami = "1.1.2"
-config = "0.12"
+config = "0.13"
 serde_derive = "1.0.125"
 serde = "1.0.126"
 serde_json = "1.0.75"

--- a/atuin-server/src/settings.rs
+++ b/atuin-server/src/settings.rs
@@ -38,7 +38,11 @@ impl Settings {
             .set_default("port", 8888)?
             .set_default("open_registration", false)?
             .set_default("db_uri", "default_uri")?
-            .add_source(Environment::with_prefix("atuin").prefix_separator("_").separator("__"));
+            .add_source(
+                Environment::with_prefix("atuin")
+                    .prefix_separator("_")
+                    .separator("__"),
+            );
 
         config_builder = if config_file.exists() {
             config_builder.add_source(ConfigFile::new(

--- a/atuin-server/src/settings.rs
+++ b/atuin-server/src/settings.rs
@@ -38,7 +38,7 @@ impl Settings {
             .set_default("port", 8888)?
             .set_default("open_registration", false)?
             .set_default("db_uri", "default_uri")?
-            .add_source(Environment::with_prefix("atuin").separator("_"));
+            .add_source(Environment::with_prefix("atuin").prefix_separator("_").separator("__"));
 
         config_builder = if config_file.exists() {
             config_builder.add_source(ConfigFile::new(


### PR DESCRIPTION
Config like `ATUIN_DB_PATH` were being parsed as `db.path` rather than `db_path`.

This would technically be a breaking change, but atuin has no nested settings just yet, so crisis averted