### PR TITLE
provide better error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "crossbeam-channel",
  "directories",
  "eyre",
+ "fs-err",
  "humantime 2.1.0",
  "indicatif",
  "itertools",
@@ -97,6 +98,7 @@ dependencies = [
  "config",
  "directories",
  "eyre",
+ "fs-err",
  "itertools",
  "log",
  "minspan",
@@ -144,6 +146,7 @@ dependencies = [
  "chrono",
  "config",
  "eyre",
+ "fs-err",
  "http",
  "log",
  "rand 0.8.5",
@@ -675,6 +678,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs-err"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd79fa345a495d3ae89fb7165fec01c0e72f41821d642dda363a1e97975652e"
 
 [[package]]
 name = "fuchsia-cprng"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ tabwriter = "1.2.1"
 crossbeam-channel = "0.5.1"
 clap = { version = "3.1.8", features = ["derive"] }
 clap_complete = "3.1.1"
+fs-err = "2.7"
 
 [profile.release]
 lto = "fat"

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -48,3 +48,4 @@ sqlx = { version = "0.5", features = [
 ] }
 minspan = "0.1.1"
 regex = "1.5.4"
+fs-err = "2.7"

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -9,6 +9,7 @@ use eyre::Result;
 use itertools::Itertools;
 use regex::Regex;
 
+use fs_err as fs;
 use sqlx::sqlite::{
     SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow,
 };
@@ -62,7 +63,7 @@ impl Sqlite {
         let create = !path.exists();
         if create {
             if let Some(dir) = path.parent() {
-                std::fs::create_dir_all(dir)?;
+                fs::create_dir_all(dir)?;
             }
         }
 

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -1,4 +1,4 @@
-use std::fs::{create_dir_all, File};
+use fs_err::{create_dir_all, File};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
@@ -76,7 +76,7 @@ impl Settings {
 
         let sync_time_path = data_dir.join("last_sync_time");
 
-        std::fs::write(sync_time_path, Utc::now().to_rfc3339())?;
+        fs_err::write(sync_time_path, Utc::now().to_rfc3339())?;
 
         Ok(())
     }
@@ -91,7 +91,7 @@ impl Settings {
             return Ok(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0));
         }
 
-        let time = std::fs::read_to_string(sync_time_path)?;
+        let time = fs_err::read_to_string(sync_time_path)?;
         let time = chrono::DateTime::parse_from_rfc3339(time.as_str())?;
 
         Ok(time.with_timezone(&Utc))
@@ -188,7 +188,7 @@ impl Settings {
 
         // Finally, set the auth token
         if Path::new(session_path.to_string().as_str()).exists() {
-            let token = std::fs::read_to_string(session_path.to_string())?;
+            let token = fs_err::read_to_string(session_path.to_string())?;
             settings.session_token = token.trim().to_string();
         } else {
             settings.session_token = String::from("not logged in");

--- a/atuin-server/Cargo.toml
+++ b/atuin-server/Cargo.toml
@@ -29,3 +29,4 @@ sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "uuid", "chrono",
 async-trait = "0.1.49"
 axum = "0.5"
 http = "0.2"
+fs-err = "2.7"

--- a/atuin-server/src/settings.rs
+++ b/atuin-server/src/settings.rs
@@ -1,4 +1,4 @@
-use std::fs::{create_dir_all, File};
+use fs_err::{create_dir_all, File};
 use std::io::prelude::*;
 use std::path::PathBuf;
 

--- a/src/command/logout.rs
+++ b/src/command/logout.rs
@@ -1,4 +1,4 @@
-use std::fs::remove_file;
+use fs_err::remove_file;
 
 pub fn run() {
     let session_path = atuin_common::utils::data_dir().join("session");


### PR DESCRIPTION
[fs-err](https://docs.rs/fs-err/2.7.0/fs_err/) is a drop in replacement for std::fs which provides better error messages.

This also addresses #270 