### PR TITLE
Use the count cache

### DIFF
--- a/atuin-server/src/database.rs
+++ b/atuin-server/src/database.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
 use std::collections::HashMap;
 
-use eyre::{eyre, Result};
-use sqlx::postgres::PgPoolOptions;
+use sqlx::{postgres::PgPoolOptions, Result};
 
 use crate::settings::HISTORY_PAGE_SIZE;
 
@@ -64,7 +63,7 @@ pub struct Postgres {
 }
 
 impl Postgres {
-    pub async fn new(uri: &str) -> Result<Self, sqlx::Error> {
+    pub async fn new(uri: &str) -> Result<Self> {
         let pool = PgPoolOptions::new()
             .max_connections(100)
             .connect(uri)
@@ -79,49 +78,29 @@ impl Postgres {
 #[async_trait]
 impl Database for Postgres {
     async fn get_session(&self, token: &str) -> Result<Session> {
-        let res: Option<Session> =
-            sqlx::query_as::<_, Session>("select * from sessions where token = $1")
-                .bind(token)
-                .fetch_optional(&self.pool)
-                .await?;
-
-        if let Some(s) = res {
-            Ok(s)
-        } else {
-            Err(eyre!("could not find session"))
-        }
+        sqlx::query_as::<_, Session>("select * from sessions where token = $1")
+            .bind(token)
+            .fetch_one(&self.pool)
+            .await
     }
 
     async fn get_user(&self, username: &str) -> Result<User> {
-        let res: Option<User> =
-            sqlx::query_as::<_, User>("select * from users where username = $1")
-                .bind(username)
-                .fetch_optional(&self.pool)
-                .await?;
-
-        if let Some(u) = res {
-            Ok(u)
-        } else {
-            Err(eyre!("could not find user"))
-        }
+        sqlx::query_as::<_, User>("select * from users where username = $1")
+            .bind(username)
+            .fetch_one(&self.pool)
+            .await
     }
 
     async fn get_session_user(&self, token: &str) -> Result<User> {
-        let res: Option<User> = sqlx::query_as::<_, User>(
+        sqlx::query_as::<_, User>(
             "select * from users 
             inner join sessions 
             on users.id = sessions.user_id 
             and sessions.token = $1",
         )
         .bind(token)
-        .fetch_optional(&self.pool)
-        .await?;
-
-        if let Some(u) = res {
-            Ok(u)
-        } else {
-            Err(eyre!("could not find user"))
-        }
+        .fetch_one(&self.pool)
+        .await
     }
 
     async fn count_history(&self, user: &User) -> Result<i64> {
@@ -317,17 +296,10 @@ impl Database for Postgres {
     }
 
     async fn get_user_session(&self, u: &User) -> Result<Session> {
-        let res: Option<Session> =
-            sqlx::query_as::<_, Session>("select * from sessions where user_id = $1")
-                .bind(u.id)
-                .fetch_optional(&self.pool)
-                .await?;
-
-        if let Some(s) = res {
-            Ok(s)
-        } else {
-            Err(eyre!("could not find session"))
-        }
+        sqlx::query_as::<_, Session>("select * from sessions where user_id = $1")
+            .bind(u.id)
+            .fetch_one(&self.pool)
+            .await
     }
 
     async fn oldest_history(&self, user: &User) -> Result<History> {


### PR DESCRIPTION
By default read from the count cache - if there is no value there, then
do a full COUNT. The cache will be filled when the user posts up some
more history

Eventually I'd like to replace the full COUNT function with reading from
the cache, but that can only be done once all users have a cached value

