### PR TITLE
Fix SQL cache query

### DIFF
--- a/atuin-server/src/database.rs
+++ b/atuin-server/src/database.rs
@@ -120,7 +120,7 @@ impl Database for Postgres {
     }
 
     async fn count_history_cached(&self, user: &User) -> Result<i64> {
-        let res: (i64,) = sqlx::query_as(
+        let res: (i32,) = sqlx::query_as(
             "select total from total_history_count_user
             where user_id = $1",
         )
@@ -128,7 +128,7 @@ impl Database for Postgres {
         .fetch_one(&self.pool)
         .await?;
 
-        Ok(res.0)
+        Ok(res.0 as i64)
     }
 
     async fn count_history_range(


### PR DESCRIPTION
I just deployed the older version and it was falling back on the full
count. Turns out this is because it won't upcast from INT4 to INT8
automatically, and it has to be manual

At some point the underlying total should be changed to int8, but also I
highly doubt anyone will have enough shell history to fill an int4 lol