### PR TITLE
History filter

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
         key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Run cargo test
-      run: cargo test --workspace
+      run: ATUIN_SESSION=beepboopiamasession cargo test --workspace
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "tracing-subscriber",
  "tui",
  "unicode-width",
+ "whoami",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ crossbeam-channel = "0.5.1"
 clap = { version = "3.1.11", features = ["derive"] }
 clap_complete = "3.1.2"
 fs-err = "2.7"
+whoami = "1.1.2"
 
 
 [dependencies.tracing-subscriber]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ I wanted to. And I **really** don't want to.
 - calculate statistics such as "most used command"
 - old history file is not replaced
 - quick-jump to previous items with <kbd>Alt-\<num\></kbd>
+- switch filter modes via ctrl-r; search history just from the current session, directory, or globally
 
 ## Documentation
 

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -23,6 +23,21 @@ pub enum SearchMode {
     Fuzzy,
 }
 
+#[derive(Clone, Debug, Deserialize, Copy)]
+pub enum FilterMode {
+    #[serde(rename = "global")]
+    Global,
+
+    #[serde(rename = "host")]
+    Host,
+
+    #[serde(rename = "session")]
+    Session,
+
+    #[serde(rename = "directory")]
+    Directory,
+}
+
 // FIXME: Can use upstream Dialect enum if https://github.com/stevedonovan/chrono-english/pull/16 is merged
 #[derive(Clone, Debug, Deserialize, Copy)]
 pub enum Dialect {
@@ -65,6 +80,7 @@ pub struct Settings {
     pub key_path: String,
     pub session_path: String,
     pub search_mode: SearchMode,
+    pub filter_mode: FilterMode,
     // This is automatically loaded when settings is created. Do not set in
     // config! Keep secrets and settings apart.
     pub session_token: String,
@@ -147,6 +163,7 @@ impl Settings {
             .set_default("sync_frequency", "1h")?
             .set_default("sync_address", "https://api.atuin.sh")?
             .set_default("search_mode", "prefix")?
+            .set_default("filter_mode", "global")?
             .set_default("session_token", "")?
             .set_default("style", "auto")?
             .add_source(

--- a/docs/config.md
+++ b/docs/config.md
@@ -102,6 +102,20 @@ the search syntax [described below](#fuzzy-search-syntax).
 
 Defaults to "prefix"
 
+### `filter_mode`
+
+The default filter to use when searching
+
+| Column1   | Column2	|
+|--------------- | --------------- |
+| global (default)   | Search history from all hosts, all sessions, all directories  |
+| host   | Search history just from this host   |
+| session   | Search history just from the current session   |
+| directory | Search history just from the current directory|
+
+Filter modes can still be toggled via ctrl-r
+
+
 ```
 search_mode = "fulltext"
 ```

--- a/src/command/client/history.rs
+++ b/src/command/client/history.rs
@@ -6,7 +6,7 @@ use clap::Subcommand;
 use eyre::Result;
 use tabwriter::TabWriter;
 
-use atuin_client::database::Database;
+use atuin_client::database::{current_context, Database};
 use atuin_client::history::History;
 use atuin_client::settings::Settings;
 use atuin_client::sync;
@@ -97,6 +97,8 @@ impl Cmd {
         settings: &Settings,
         db: &mut (impl Database + Send + Sync),
     ) -> Result<()> {
+        let context = current_context();
+
         match self {
             Self::Start { command: words } => {
                 let command = words.join(" ");
@@ -168,7 +170,7 @@ impl Cmd {
                 };
 
                 let history = match (session, cwd) {
-                    (None, None) => db.list(settings.filter_mode, None, false).await?,
+                    (None, None) => db.list(settings.filter_mode, &context, None, false).await?,
                     (None, Some(cwd)) => {
                         let query = format!("select * from history where cwd = '{}';", cwd);
                         db.query_history(&query).await?

--- a/src/command/client/history.rs
+++ b/src/command/client/history.rs
@@ -168,7 +168,7 @@ impl Cmd {
                 };
 
                 let history = match (session, cwd) {
-                    (None, None) => db.list(None, false).await?,
+                    (None, None) => db.list(settings.filter_mode, None, false).await?,
                     (None, Some(cwd)) => {
                         let query = format!("select * from history where cwd = '{}';", cwd);
                         db.query_history(&query).await?

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -16,7 +16,7 @@ use unicode_width::UnicodeWidthStr;
 use atuin_client::{
     database::Database,
     history::History,
-    settings::{SearchMode, Settings},
+    settings::{SearchMode, Settings, FilterMode},
 };
 
 use super::event::{Event, Events};
@@ -90,6 +90,8 @@ impl Cmd {
 
 struct State {
     input: String,
+
+    filter_mode: FilterMode,
 
     results: Vec<History>,
 
@@ -233,8 +235,8 @@ async fn query_results(
     db: &mut (impl Database + Send + Sync),
 ) -> Result<()> {
     let results = match app.input.as_str() {
-        "" => db.list(Some(200), true).await?,
-        i => db.search(Some(200), search_mode, i).await?,
+        "" => db.list(app.filter_mode, Some(200), true).await?,
+        i => db.search(Some(200), search_mode, app.filter_mode, i).await?,
     };
 
     app.results = results;
@@ -277,11 +279,11 @@ async fn key_handler(
         }
         Key::Char(c) => {
             app.input.push(c);
-            query_results(app, search_mode, db).await.unwrap();
+            query_results(app, search_mode,  db).await.unwrap();
         }
         Key::Backspace => {
             app.input.pop();
-            query_results(app, search_mode, db).await.unwrap();
+            query_results(app, search_mode,  db).await.unwrap();
         }
         // \u{7f} is escape sequence for backspace
         Key::Alt('\u{7f}') => {
@@ -294,10 +296,20 @@ async fn key_handler(
             } else {
                 app.input = words[0..(words.len() - 1)].join(" ");
             }
-            query_results(app, search_mode, db).await.unwrap();
+            query_results(app, search_mode,  db).await.unwrap();
         }
         Key::Ctrl('u') => {
             app.input = String::from("");
+            query_results(app, search_mode,  db).await.unwrap();
+        }
+        Key::Ctrl('r') => {
+            app.filter_mode = match app.filter_mode {
+                FilterMode::Global => FilterMode::Host,
+                FilterMode::Host=> FilterMode::Session,
+                FilterMode::Session=> FilterMode::Directory,
+                FilterMode::Directory=> FilterMode::Global,
+            };
+
             query_results(app, search_mode, db).await.unwrap();
         }
         Key::Down | Key::Ctrl('n') => {
@@ -376,8 +388,16 @@ fn draw<T: Backend>(f: &mut Frame<'_, T>, history_count: i64, app: &mut State) {
     let help = Text::from(Spans::from(help));
     let help = Paragraph::new(help);
 
+
+    let filter_mode = match app.filter_mode{
+        FilterMode::Global => "GLOBAL",
+        FilterMode::Host=> "HOST",
+        FilterMode::Session => "SESSION",
+        FilterMode::Directory=> "DIRECTORY",
+    };
+
     let input = Paragraph::new(app.input.clone())
-        .block(Block::default().borders(Borders::ALL).title("Query"));
+        .block(Block::default().borders(Borders::ALL).title(filter_mode));
 
     let stats = Paragraph::new(Text::from(Span::raw(format!(
         "history count: {}",
@@ -451,7 +471,14 @@ fn draw_compact<T: Backend>(f: &mut Frame<'_, T>, history_count: i64, app: &mut 
     .style(Style::default().fg(Color::DarkGray))
     .alignment(Alignment::Right);
 
-    let input = Paragraph::new(format!("] {}", app.input.clone())).block(Block::default());
+    let filter_mode = match app.filter_mode{
+        FilterMode::Global => "GLOBAL",
+        FilterMode::Host=> "HOST",
+        FilterMode::Session => "SESSION",
+        FilterMode::Directory=> "DIRECTORY",
+    };
+
+    let input = Paragraph::new(format!("{}] {}", filter_mode, app.input.clone())).block(Block::default());
 
     f.render_widget(title, header_chunks[0]);
     f.render_widget(help, header_chunks[1]);
@@ -460,9 +487,11 @@ fn draw_compact<T: Backend>(f: &mut Frame<'_, T>, history_count: i64, app: &mut 
     app.render_results(f, chunks[1], Block::default());
     f.render_widget(input, chunks[2]);
 
+    let extra_width = app.input.width() + filter_mode.len();
+
     f.set_cursor(
         // Put cursor past the end of the input text
-        chunks[2].x + app.input.width() as u16 + 2,
+        chunks[2].x + extra_width as u16 + 2,
         // Move one line down, from the border to the input line
         chunks[2].y + 1,
     );
@@ -475,6 +504,7 @@ fn draw_compact<T: Backend>(f: &mut Frame<'_, T>, history_count: i64, app: &mut 
 async fn select_history(
     query: &[String],
     search_mode: SearchMode,
+    filter_mode: FilterMode,
     style: atuin_client::settings::Style,
     db: &mut (impl Database + Send + Sync),
 ) -> Result<String> {
@@ -491,6 +521,7 @@ async fn select_history(
         input: query.join(" "),
         results: Vec::new(),
         results_state: ListState::default(),
+        filter_mode,
     };
 
     query_results(&mut app, search_mode, db).await?;
@@ -551,11 +582,11 @@ pub async fn run(
     };
 
     if interactive {
-        let item = select_history(query, settings.search_mode, settings.style, db).await?;
+        let item = select_history(query, settings.search_mode, settings.filter_mode,settings.style, db).await?;
         eprintln!("{}", item);
     } else {
         let results = db
-            .search(None, settings.search_mode, query.join(" ").as_str())
+            .search(None, settings.search_mode, settings.filter_mode,query.join(" ").as_str())
             .await?;
 
         // TODO: This filtering would be better done in the SQL query, I just

--- a/src/command/client/stats.rs
+++ b/src/command/client/stats.rs
@@ -10,7 +10,7 @@ use eyre::{bail, Result};
 
 use atuin_client::database::Database;
 use atuin_client::history::History;
-use atuin_client::settings::{Settings, FilterMode};
+use atuin_client::settings::{FilterMode, Settings};
 
 #[derive(Parser)]
 #[clap(infer_subcommands = true)]

--- a/src/command/client/stats.rs
+++ b/src/command/client/stats.rs
@@ -10,7 +10,7 @@ use eyre::{bail, Result};
 
 use atuin_client::database::Database;
 use atuin_client::history::History;
-use atuin_client::settings::Settings;
+use atuin_client::settings::{Settings, FilterMode};
 
 #[derive(Parser)]
 #[clap(infer_subcommands = true)]
@@ -90,7 +90,7 @@ impl Cmd {
             }
 
             Self::All => {
-                let history = db.list(None, false).await?;
+                let history = db.list(FilterMode::Global, None, false).await?;
 
                 compute_stats(&history)?;
 

--- a/src/command/client/stats.rs
+++ b/src/command/client/stats.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
 use eyre::{bail, Result};
 
-use atuin_client::database::Database;
+use atuin_client::database::{current_context, Database};
 use atuin_client::history::History;
 use atuin_client::settings::{FilterMode, Settings};
 
@@ -71,6 +71,8 @@ impl Cmd {
         db: &mut (impl Database + Send + Sync),
         settings: &Settings,
     ) -> Result<()> {
+        let context = current_context();
+
         match self {
             Self::Day { words } => {
                 let words = if words.is_empty() {
@@ -90,7 +92,7 @@ impl Cmd {
             }
 
             Self::All => {
-                let history = db.list(FilterMode::Global, None, false).await?;
+                let history = db.list(FilterMode::Global, &context, None, false).await?;
 
                 compute_stats(&history)?;
 


### PR DESCRIPTION
Switch between different search modes to narrow down the history you
want - global search for all history, host for all history from your
current machine, session for the current shell session, and directory
for the current directory

The default can be configured via `filter_mode`