### PR TITLE
Release v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 edition = "2018"
 rust-version = "1.59"
@@ -38,9 +38,9 @@ sync = ["atuin-client/sync"]
 server = ["atuin-server", "tracing-subscriber"]
 
 [dependencies]
-atuin-server = { path = "atuin-server", version = "0.8.1", optional = true }
-atuin-client = { path = "atuin-client", version = "0.8.1", default-features = false }
-atuin-common = { path = "atuin-common", version = "0.8.1" }
+atuin-server = { path = "atuin-server", version = "0.9.0", optional = true }
+atuin-client = { path = "atuin-client", version = "0.9.0", default-features = false }
+atuin-common = { path = "atuin-common", version = "0.9.0" }
 
 log = "0.4"
 pretty_env_logger = "0.4"

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-client"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 edition = "2018"
 license = "MIT"
@@ -22,7 +22,7 @@ sync = [
 ]
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "0.8.1" }
+atuin-common = { path = "../atuin-common", version = "0.9.0" }
 
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }

--- a/atuin-common/Cargo.toml
+++ b/atuin-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-common"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 edition = "2018"
 license = "MIT"

--- a/atuin-server/Cargo.toml
+++ b/atuin-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-server"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 edition = "2018"
 license = "MIT"
@@ -9,7 +9,7 @@ homepage = "https://atuin.sh"
 repository = "https://github.com/ellie/atuin"
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "0.8.1" }
+atuin-common = { path = "../atuin-common", version = "0.9.0" }
 
 tracing = "0.1"
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
89549b3 Bump uuid from 0.8.2 to 1.0.0 (#311)
831cc98 Fix typos in the docs. (#171)
7436e4f feature-flags (#328)
508d4f4 History filter (#329)
02c70de refactor (#327)
a9d1ece Added docker-compose.yml (#325)
b8bdd83 Bump clap from 3.1.10 to 3.1.11 (#323)
52a3d0c Bump tracing from 0.1.33 to 0.1.34 (#324)
79597b0 Bump clap_complete from 3.1.1 to 3.1.2 (#316)
5aca611 Allow for larger commands (#321)
9085485 tracing (#315)
98d70fb treat popos as ubuntu (#319)
d57f549 refactor commands for better separation (#313)
24e2971 Fix SQL cache query (#318)
fe05d86 Fix delete trigger (#317)
48747e3 A few minor tweaks (#314)
ed4e07d Use the count cache (#312)
6e11b8e Bump clap from 3.1.9 to 3.1.10 (#309)
44e417d Bump axum from 0.5.1 to 0.5.3 (#310)
b98a378 Add count trigger (#308)
7fe523a Bump sqlx from 0.5.11 to 0.5.13 (#305)
c5ab2a4 Bump clap from 3.1.8 to 3.1.9 (#306)
55f66c8 Bump cli-table from 0.4.6 to 0.4.7 (#297)
69279d2 Bump config from 0.13.0 to 0.13.1 (#303)
d94cdae README: add MacPorts installation instructions (#302)
f4240aa Initial implementation of calendar API (#298)
3c5fbc5 provide better error messages (#300)
bc45bab remove default db uri (#299)
4897f4a Bump rmp-serde from 0.15.5 to 1.0.0 (#264)
5b2e828 Bump directories from 3.0.2 to 4.0.1 (#246)
016386c Bump urlencoding from 1.3.3 to 2.1.0 (#208)
a95018c goodbye warp, hello axum (#296)
3b7ed7c fix env config parsing (#295)