### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "atuin"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "atuin-client",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "rust-crypto",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "atuin-common",


### PR DESCRIPTION
Hello!

I saw that manifest files of the crates are updated in [22a7d88](https://github.com/ellie/atuin/commit/22a7d8866bb82cbf68b4acfc61fba464376730f1) but the versions in `Cargo.lock` are not updated.

I spotted this issue while building the [Arch Linux package](https://archlinux.org/packages/community/x86_64/atuin/):

```sh
$ cargo build --locked
error: the lock file /build/atuin/src/atuin-0.9.0/Cargo.lock needs to be updated but --locked was passed to prevent this
```

`--locked` flag is required for the reproducibility of the package. Read more about it [here](https://wiki.archlinux.org/title/Rust_package_guidelines#Prepare).

This PR updates `Cargo.lock` for matching the versions in `Cargo.toml`. (i.e. I simply ran `cargo build` once for updating the lock file.)

P.S. Congrats on the new release! I see that you've added some nice features. I'm curious about the reason behind switching to `axum` :bear:

