### PR TITLE
Use `--locked` flag for CI builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,7 @@ jobs:
       with:
         use-cross: ${{ matrix.job.use-cross }}
         command: build
-        args: --release --target=${{ matrix.job.target }}
+        args: --locked --release --target=${{ matrix.job.target }}
 
     - name: Strip debug information from executable
       id: strip

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,16 +31,16 @@ jobs:
         key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Run cargo build common
-      run: cargo build -p atuin-common --release
+      run: cargo build -p atuin-common --locked --release
 
     - name: Run cargo build client
-      run: cargo build -p atuin-client --release
+      run: cargo build -p atuin-client --locked --release
 
     - name: Run cargo build server
-      run: cargo build -p atuin-server --release
+      run: cargo build -p atuin-server --locked --release
 
     - name: Run cargo build main
-      run: cargo build --all --release && strip target/release/atuin
+      run: cargo build --all --locked --release && strip target/release/atuin
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds `--locked` flag to `cargo build` commands in CI/CD workflows. This is beneficial for spotting the outdated lockfile issues mentioned in #336

