### PR TITLE
Release v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "atuin"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "atuin-client",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "rust-crypto",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "atuin-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 edition = "2018"
 rust-version = "1.59"
@@ -38,9 +38,9 @@ sync = ["atuin-client/sync"]
 server = ["atuin-server", "tracing-subscriber"]
 
 [dependencies]
-atuin-server = { path = "atuin-server", version = "0.9.0", optional = true }
-atuin-client = { path = "atuin-client", version = "0.9.0", default-features = false }
-atuin-common = { path = "atuin-common", version = "0.9.0" }
+atuin-server = { path = "atuin-server", version = "0.9.1", optional = true }
+atuin-client = { path = "atuin-client", version = "0.9.1", default-features = false }
+atuin-common = { path = "atuin-common", version = "0.9.1" }
 
 log = "0.4"
 pretty_env_logger = "0.4"

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-client"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 edition = "2018"
 license = "MIT"
@@ -22,7 +22,7 @@ sync = [
 ]
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "0.9.0" }
+atuin-common = { path = "../atuin-common", version = "0.9.1" }
 
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }

--- a/atuin-common/Cargo.toml
+++ b/atuin-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-common"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 edition = "2018"
 license = "MIT"

--- a/atuin-server/Cargo.toml
+++ b/atuin-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-server"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 edition = "2018"
 license = "MIT"
@@ -9,7 +9,7 @@ homepage = "https://atuin.sh"
 repository = "https://github.com/ellie/atuin"
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "0.9.0" }
+atuin-common = { path = "../atuin-common", version = "0.9.1" }
 
 tracing = "0.1"
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
Fixed to include an updated lockfile that was missed in the last release

Thank you for the rapid report @orhun!

a050faa Use `--locked` flag for CI builds (#337)
8737474 Update Cargo.lock (#336)
eab1dbf sql builder (#333)