### PR TITLE
history list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,6 @@ dependencies = [
  "indicatif",
  "itertools",
  "log",
- "owo-colors",
  "pretty_env_logger",
  "serde",
  "serde_json",
@@ -1380,12 +1379,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-
-[[package]]
-name = "owo-colors"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,10 +90,10 @@ dependencies = [
  "indicatif",
  "itertools",
  "log",
+ "owo-colors",
  "pretty_env_logger",
  "serde",
  "serde_json",
- "tabwriter",
  "termion",
  "tokio",
  "tracing-subscriber",
@@ -1382,6 +1382,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
+name = "owo-colors"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,15 +2185,6 @@ name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
-
-[[package]]
-name = "tabwriter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36205cfc997faadcc4b0b87aaef3fbedafe20d38d4959a7ca6ff803564051111"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "termcolor"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "directories",
  "eyre",
  "fs-err",
+ "hex",
  "itertools",
  "lazy_static",
  "log",
@@ -123,9 +124,9 @@ dependencies = [
  "regex",
  "reqwest",
  "rmp-serde",
- "rust-crypto",
  "serde",
  "serde_json",
+ "sha2",
  "shellexpand",
  "sodiumoxide",
  "sql-builder",
@@ -141,7 +142,6 @@ name = "atuin-common"
 version = "0.9.1"
 dependencies = [
  "chrono",
- "rust-crypto",
  "serde",
  "uuid",
 ]
@@ -160,8 +160,7 @@ dependencies = [
  "eyre",
  "fs-err",
  "http",
- "rand 0.8.5",
- "rust-crypto",
+ "rand",
  "serde",
  "serde_json",
  "sodiumoxide",
@@ -725,12 +724,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd79fa345a495d3ae89fb7165fec01c0e72f41821d642dda363a1e97975652e"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,12 +786,6 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
-
-[[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
@@ -1618,36 +1605,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1657,23 +1621,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1682,15 +1631,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1835,19 +1775,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-crypto"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
-dependencies = [
- "gcc",
- "libc",
- "rand 0.3.23",
- "rustc-serialize",
- "time",
-]
-
-[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,12 +1783,6 @@ dependencies = [
  "cfg-if",
  "ordered-multimap",
 ]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustls"
@@ -2172,7 +2093,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "rustls 0.19.1",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,12 +60,12 @@ chrono-english = "0.1.4"
 cli-table = "0.4"
 base64 = "0.13.0"
 humantime = "2.1.0"
-tabwriter = "1.2.1"
 crossbeam-channel = "0.5.1"
 clap = { version = "3.1.11", features = ["derive"] }
 clap_complete = "3.1.2"
 fs-err = "2.7"
 whoami = "1.1.2"
+owo-colors = "3.4.0"
 
 [dependencies.tracing-subscriber]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ clap = { version = "3.1.11", features = ["derive"] }
 clap_complete = "3.1.2"
 fs-err = "2.7"
 whoami = "1.1.2"
-owo-colors = "3.4.0"
 
 [dependencies.tracing-subscriber]
 version = "0.3"

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -16,7 +16,8 @@ sync = [
   "urlencoding",
   "sodiumoxide",
   "reqwest",
-  "rust-crypto",
+  "sha2",
+  "hex",
   "rmp-serde",
   "base64",
 ]
@@ -56,7 +57,8 @@ reqwest = { version = "0.11", features = [
   "json",
   "rustls-tls",
 ], default-features = false, optional = true }
-rust-crypto = { version = "^0.2", optional = true }
+hex = { version = "0.4", optional = true }
+sha2 = { version = "0.10", optional = true }
 rmp-serde = { version = "1.0.0", optional = true }
 base64 = { version = "0.13.0", optional = true }
 

--- a/atuin-client/src/api_client.rs
+++ b/atuin-client/src/api_client.rs
@@ -10,10 +10,10 @@ use atuin_common::api::{
     AddHistoryRequest, CountResponse, LoginRequest, LoginResponse, RegisterResponse,
     SyncHistoryResponse,
 };
-use atuin_common::utils::hash_str;
 
 use crate::encryption::{decode_key, decrypt};
 use crate::history::History;
+use crate::sync::hash_str;
 
 static APP_USER_AGENT: &str = concat!("atuin/", env!("CARGO_PKG_VERSION"),);
 

--- a/atuin-client/src/history.rs
+++ b/atuin-client/src/history.rs
@@ -45,4 +45,8 @@ impl History {
             hostname,
         }
     }
+
+    pub fn success(&self) -> bool {
+        self.exit == 0 || self.duration == -1
+    }
 }

--- a/atuin-client/src/sync.rs
+++ b/atuin-client/src/sync.rs
@@ -3,12 +3,19 @@ use std::convert::TryInto;
 use chrono::prelude::*;
 use eyre::Result;
 
-use atuin_common::{api::AddHistoryRequest, utils::hash_str};
+use atuin_common::{api::AddHistoryRequest};
 
 use crate::api_client;
 use crate::database::Database;
 use crate::encryption::{encrypt, load_encoded_key, load_key};
 use crate::settings::{Settings, HISTORY_PAGE_SIZE};
+
+pub fn hash_str(string: &str) -> String {
+    use sha2::{Sha256, Digest};
+    let mut hasher = Sha256::new();
+    hasher.update(string.as_bytes());
+    hex::encode(hasher.finalize())
+}
 
 // Currently sync is kinda naive, and basically just pages backwards through
 // history. This means newly added stuff shows up properly! We also just use

--- a/atuin-client/src/sync.rs
+++ b/atuin-client/src/sync.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use chrono::prelude::*;
 use eyre::Result;
 
-use atuin_common::{api::AddHistoryRequest};
+use atuin_common::api::AddHistoryRequest;
 
 use crate::api_client;
 use crate::database::Database;
@@ -11,7 +11,7 @@ use crate::encryption::{encrypt, load_encoded_key, load_key};
 use crate::settings::{Settings, HISTORY_PAGE_SIZE};
 
 pub fn hash_str(string: &str) -> String {
-    use sha2::{Sha256, Digest};
+    use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(string.as_bytes());
     hex::encode(hasher.finalize())

--- a/atuin-common/Cargo.toml
+++ b/atuin-common/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/ellie/atuin"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rust-crypto = "^0.2"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0.126", features = ["derive"] }
 uuid = { version = "1.0", features = ["v4"] }

--- a/atuin-common/src/utils.rs
+++ b/atuin-common/src/utils.rs
@@ -3,15 +3,6 @@ use std::path::PathBuf;
 use chrono::NaiveDate;
 use uuid::Uuid;
 
-pub fn hash_str(string: &str) -> String {
-    use crypto::digest::Digest;
-    use crypto::sha2::Sha256;
-    let mut hasher = Sha256::new();
-    hasher.input_str(string);
-
-    hasher.result_str()
-}
-
 pub fn uuid_v4() -> String {
     Uuid::new_v4().as_simple().to_string()
 }

--- a/atuin-server/Cargo.toml
+++ b/atuin-server/Cargo.toml
@@ -22,7 +22,6 @@ serde_json = "1.0.75"
 sodiumoxide = "0.2.6"
 base64 = "0.13.0"
 rand = "0.8.4"
-rust-crypto = "^0.2"
 tokio = { version = "1", features = ["full"] }
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "chrono", "postgres" ] }
 async-trait = "0.1.49"

--- a/src/command/client/history.rs
+++ b/src/command/client/history.rs
@@ -81,11 +81,12 @@ pub fn print_human_list(w: &mut StdoutLock, h: &[History]) {
         let time = h.timestamp.format("%Y-%m-%d %H:%M:%S");
         let cmd = h.command.trim();
 
-        let duration = if h.exit == 0 {
-            duration.color(owo_colors::AnsiColors::Green)
+        let exit_color = if h.success() {
+            owo_colors::AnsiColors::Green
         } else {
-            duration.color(owo_colors::AnsiColors::Red)
+            owo_colors::AnsiColors::Red
         };
+        let duration = duration.color(exit_color);
 
         writeln!(w, "{time} · {duration}\t{cmd}").expect("failed to write history");
     }

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -196,7 +196,7 @@ impl State {
 
                 let duration = Span::styled(
                     duration,
-                    Style::default().fg(if m.exit == 0 || m.duration == -1 {
+                    Style::default().fg(if m.success() {
                         Color::Green
                     } else {
                         Color::Red


### PR DESCRIPTION
## remove rust-crypto

sha2 is much more trusted and up to date than rust-crypto.

## update history printing code

Our use of TabWriter ended up causing some awkward behaviour. TabWriter tries to make each tab stop be at the same position, and the fact we had very varying sizes in our command stage, caused these tabs stops to be sometimes many lines down.

In my case, I had a single command span 5 lines, this caused all other commands to similarly span those same 5 lines without needing to.

The fix here is to swap the order of the command and the duration.

~~For a little flare, I've added some colour to the duration to be more consistent with some of our other setups~~ removed as I think our primary use case for this subcommand was interop with fzf, which does not support ansi