### PR TITLE
ignore JetBrains IDEs, tidy-up imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 */target
 .env
+
+# JetBrains IDEs
+.idea/

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,4 @@
+reorder_imports = true
+# uncomment once stable
+#imports_granularity = "crate"
+#group_imports = "StdExternalCrate"

--- a/atuin-client/src/api_client.rs
+++ b/atuin-client/src/api_client.rs
@@ -2,8 +2,10 @@ use std::collections::HashMap;
 
 use chrono::Utc;
 use eyre::{bail, Result};
-use reqwest::header::{HeaderMap, AUTHORIZATION, USER_AGENT};
-use reqwest::{StatusCode, Url};
+use reqwest::{
+    header::{HeaderMap, AUTHORIZATION, USER_AGENT},
+    StatusCode, Url,
+};
 use sodiumoxide::crypto::secretbox;
 
 use atuin_common::api::{
@@ -11,9 +13,11 @@ use atuin_common::api::{
     SyncHistoryResponse,
 };
 
-use crate::encryption::{decode_key, decrypt};
-use crate::history::History;
-use crate::sync::hash_str;
+use crate::{
+    encryption::{decode_key, decrypt},
+    history::History,
+    sync::hash_str,
+};
 
 static APP_USER_AGENT: &str = concat!("atuin/", env!("CARGO_PKG_VERSION"),);
 

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -1,10 +1,7 @@
-use std::env;
-use std::path::Path;
-use std::str::FromStr;
+use std::{env, path::Path, str::FromStr};
 
 use async_trait::async_trait;
-use chrono::prelude::*;
-use chrono::Utc;
+use chrono::{prelude::*, Utc};
 use fs_err as fs;
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -15,9 +12,11 @@ use sqlx::{
     Result, Row,
 };
 
-use super::history::History;
-use super::ordering;
-use super::settings::{FilterMode, SearchMode};
+use super::{
+    history::History,
+    ordering,
+    settings::{FilterMode, SearchMode},
+};
 
 pub struct Context {
     session: String,

--- a/atuin-client/src/encryption.rs
+++ b/atuin-client/src/encryption.rs
@@ -8,16 +8,14 @@
 // clients must share the secret in order to be able to sync, as it is needed
 // to decrypt
 
-use fs_err as fs;
-use serde::{Deserialize, Serialize};
-use std::io::prelude::*;
-use std::path::PathBuf;
+use std::{io::prelude::*, path::PathBuf};
 
 use eyre::{eyre, Context, Result};
+use fs_err as fs;
+use serde::{Deserialize, Serialize};
 use sodiumoxide::crypto::secretbox;
 
-use crate::history::History;
-use crate::settings::Settings;
+use crate::{history::History, settings::Settings};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EncryptedHistory {

--- a/atuin-client/src/history.rs
+++ b/atuin-client/src/history.rs
@@ -1,9 +1,9 @@
 use std::env;
 
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
 
 use atuin_common::utils::uuid_v4;
-use serde::{Deserialize, Serialize};
 
 // Any new fields MUST be Optional<>!
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, sqlx::FromRow)]

--- a/atuin-client/src/import/fish.rs
+++ b/atuin-client/src/import/fish.rs
@@ -7,8 +7,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use chrono::prelude::*;
-use chrono::Utc;
+use chrono::{prelude::*, Utc};
 use directories::BaseDirs;
 use eyre::{eyre, Result};
 

--- a/atuin-client/src/import/mod.rs
+++ b/atuin-client/src/import/mod.rs
@@ -1,5 +1,7 @@
-use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
-use std::path::{Path, PathBuf};
+use std::{
+    io::{BufRead, BufReader, Read, Seek, SeekFrom},
+    path::{Path, PathBuf},
+};
 
 use eyre::Result;
 

--- a/atuin-client/src/import/resh.rs
+++ b/atuin-client/src/import/resh.rs
@@ -4,11 +4,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use atuin_common::utils::uuid_v4;
 use chrono::{TimeZone, Utc};
 use directories::UserDirs;
 use eyre::{eyre, Result};
 use serde::Deserialize;
+
+use atuin_common::utils::uuid_v4;
 
 use super::{count_lines, Importer};
 use crate::history::History;

--- a/atuin-client/src/import/zsh.rs
+++ b/atuin-client/src/import/zsh.rs
@@ -7,8 +7,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use chrono::prelude::*;
-use chrono::Utc;
+use chrono::{prelude::*, Utc};
 use directories::UserDirs;
 use eyre::{eyre, Result};
 use itertools::Itertools;

--- a/atuin-client/src/ordering.rs
+++ b/atuin-client/src/ordering.rs
@@ -1,6 +1,6 @@
-use super::history::History;
-use super::settings::SearchMode;
 use minspan::minspan;
+
+use super::{history::History, settings::SearchMode};
 
 pub fn reorder_fuzzy(mode: SearchMode, query: &str, res: Vec<History>) -> Vec<History> {
     match mode {

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -1,13 +1,14 @@
-use fs_err::{create_dir_all, File};
-use serde::Deserialize;
-use std::io::prelude::*;
-use std::path::{Path, PathBuf};
+use std::{
+    io::prelude::*,
+    path::{Path, PathBuf},
+};
 
-use chrono::prelude::*;
-use chrono::Utc;
+use chrono::{prelude::*, Utc};
 use config::{Config, Environment, File as ConfigFile, FileFormat};
 use eyre::{eyre, Context, Result};
+use fs_err::{create_dir_all, File};
 use parse_duration::parse;
+use serde::Deserialize;
 
 pub const HISTORY_PAGE_SIZE: i64 = 100;
 

--- a/atuin-client/src/sync.rs
+++ b/atuin-client/src/sync.rs
@@ -5,10 +5,12 @@ use eyre::Result;
 
 use atuin_common::api::AddHistoryRequest;
 
-use crate::api_client;
-use crate::database::Database;
-use crate::encryption::{encrypt, load_encoded_key, load_key};
-use crate::settings::{Settings, HISTORY_PAGE_SIZE};
+use crate::{
+    api_client,
+    database::Database,
+    encryption::{encrypt, load_encoded_key, load_key},
+    settings::{Settings, HISTORY_PAGE_SIZE},
+};
 
 pub fn hash_str(string: &str) -> String {
     use sha2::{Digest, Sha256};

--- a/atuin-server/src/database.rs
+++ b/atuin-server/src/database.rs
@@ -1,16 +1,16 @@
-use async_trait::async_trait;
 use std::collections::HashMap;
-use tracing::{debug, instrument};
 
-use sqlx::{postgres::PgPoolOptions, Result};
-
-use crate::settings::HISTORY_PAGE_SIZE;
-
-use super::calendar::{TimePeriod, TimePeriodInfo};
-use super::models::{History, NewHistory, NewSession, NewUser, Session, User};
-
+use async_trait::async_trait;
 use chrono::{Datelike, TimeZone};
 use chronoutil::RelativeDuration;
+use sqlx::{postgres::PgPoolOptions, Result};
+use tracing::{debug, instrument};
+
+use super::{
+    calendar::{TimePeriod, TimePeriodInfo},
+    models::{History, NewHistory, NewSession, NewUser, Session, User},
+};
+use crate::settings::HISTORY_PAGE_SIZE;
 
 use atuin_common::utils::get_days_from_month;
 

--- a/atuin-server/src/handlers/history.rs
+++ b/atuin-server/src/handlers/history.rs
@@ -1,16 +1,20 @@
-use axum::extract::Query;
-use axum::{extract::Path, Extension, Json};
-use http::StatusCode;
 use std::collections::HashMap;
+
+use axum::{
+    extract::{Path, Query},
+    Extension, Json,
+};
+use http::StatusCode;
 use tracing::{debug, error, instrument};
 
-use crate::database::{Database, Postgres};
-use crate::models::{NewHistory, User};
-use atuin_common::api::*;
-
-use crate::calendar::{TimePeriod, TimePeriodInfo};
-
 use super::{ErrorResponse, ErrorResponseStatus};
+use crate::{
+    calendar::{TimePeriod, TimePeriodInfo},
+    database::{Database, Postgres},
+    models::{NewHistory, User},
+};
+
+use atuin_common::api::*;
 
 #[instrument(skip_all, fields(user.id = user.id))]
 pub async fn count(

--- a/atuin-server/src/handlers/mod.rs
+++ b/atuin-server/src/handlers/mod.rs
@@ -1,6 +1,7 @@
+use std::borrow::Cow;
+
 use axum::{response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 
 pub mod history;
 pub mod user;

--- a/atuin-server/src/handlers/user.rs
+++ b/atuin-server/src/handlers/user.rs
@@ -1,18 +1,19 @@
 use std::borrow::Borrow;
 
-use atuin_common::api::*;
-use axum::extract::Path;
-use axum::{Extension, Json};
+use axum::{extract::Path, Extension, Json};
 use http::StatusCode;
 use sodiumoxide::crypto::pwhash::argon2id13;
 use tracing::{debug, error, instrument};
 use uuid::Uuid;
 
-use crate::database::{Database, Postgres};
-use crate::models::{NewSession, NewUser};
-use crate::settings::Settings;
-
 use super::{ErrorResponse, ErrorResponseStatus};
+use crate::{
+    database::{Database, Postgres},
+    models::{NewSession, NewUser},
+    settings::Settings,
+};
+
+use atuin_common::api::*;
 
 pub fn verify_str(secret: &str, verify: &str) -> bool {
     sodiumoxide::init().unwrap();

--- a/atuin-server/src/settings.rs
+++ b/atuin-server/src/settings.rs
@@ -1,10 +1,9 @@
-use fs_err::{create_dir_all, File};
-use serde::{Deserialize, Serialize};
-use std::io::prelude::*;
-use std::path::PathBuf;
+use std::{io::prelude::*, path::PathBuf};
 
 use config::{Config, Environment, File as ConfigFile, FileFormat};
 use eyre::{eyre, Result};
+use fs_err::{create_dir_all, File};
+use serde::{Deserialize, Serialize};
 
 pub const HISTORY_PAGE_SIZE: i64 = 100;
 

--- a/src/command/client.rs
+++ b/src/command/client.rs
@@ -1,11 +1,10 @@
-use clap::CommandFactory;
-use clap::Subcommand;
-use clap_complete::Shell;
-use clap_complete::{generate, generate_to};
+use std::path::PathBuf;
+
+use clap::{CommandFactory, Subcommand};
+use clap_complete::{generate, generate_to, Shell};
 use eyre::{Result, WrapErr};
 
-use atuin_client::database::Sqlite;
-use atuin_client::settings::Settings;
+use atuin_client::{database::Sqlite, settings::Settings};
 use atuin_common::utils::uuid_v4;
 
 #[cfg(feature = "sync")]
@@ -17,8 +16,6 @@ mod import;
 mod init;
 mod search;
 mod stats;
-
-use std::path::PathBuf;
 
 #[derive(Subcommand)]
 #[clap(infer_subcommands = true)]

--- a/src/command/client/event.rs
+++ b/src/command/client/event.rs
@@ -1,9 +1,7 @@
-use std::thread;
-use std::time::Duration;
+use std::{thread, time::Duration};
 
 use crossbeam_channel::unbounded;
-use termion::event::Key;
-use termion::input::TermRead;
+use termion::{event::Key, input::TermRead};
 
 pub enum Event<I> {
     Input(I),

--- a/src/command/client/history.rs
+++ b/src/command/client/history.rs
@@ -1,13 +1,17 @@
-use std::env;
-use std::io::{StdoutLock, Write};
-use std::time::Duration;
+use std::{
+    env,
+    io::{StdoutLock, Write},
+    time::Duration,
+};
 
 use clap::Subcommand;
 use eyre::Result;
 
-use atuin_client::database::{current_context, Database};
-use atuin_client::history::History;
-use atuin_client::settings::Settings;
+use atuin_client::{
+    database::{current_context, Database},
+    history::History,
+    settings::Settings,
+};
 
 #[cfg(feature = "sync")]
 use atuin_client::sync;

--- a/src/command/client/import.rs
+++ b/src/command/client/import.rs
@@ -1,13 +1,14 @@
 use std::{env, path::PathBuf};
 
-use atuin_client::import::fish::Fish;
 use clap::Parser;
 use eyre::{eyre, Result};
-
-use atuin_client::import::{bash::Bash, zsh::Zsh};
-use atuin_client::{database::Database, import::Importer};
-use atuin_client::{history::History, import::resh::Resh};
 use indicatif::ProgressBar;
+
+use atuin_client::{
+    database::Database,
+    history::History,
+    import::{bash::Bash, fish::Fish, resh::Resh, zsh::Zsh, Importer},
+};
 
 #[derive(Parser)]
 #[clap(infer_subcommands = true)]

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -1,8 +1,8 @@
+use std::{env, io::stdout, ops::Sub, time::Duration};
+
 use chrono::Utc;
 use clap::Parser;
 use eyre::Result;
-use std::env;
-use std::{io::stdout, ops::Sub, time::Duration};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::{Backend, TermionBackend},
@@ -22,8 +22,10 @@ use atuin_client::{
     settings::{FilterMode, SearchMode, Settings},
 };
 
-use super::event::{Event, Events};
-use super::history::ListMode;
+use super::{
+    event::{Event, Events},
+    history::ListMode,
+};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/src/command/client/stats.rs
+++ b/src/command/client/stats.rs
@@ -1,16 +1,16 @@
 use std::collections::HashMap;
 
-use chrono::prelude::*;
-use chrono::Duration;
+use chrono::{prelude::*, Duration};
 use chrono_english::parse_date_string;
-
 use clap::Parser;
 use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
 use eyre::{bail, Result};
 
-use atuin_client::database::{current_context, Database};
-use atuin_client::history::History;
-use atuin_client::settings::{FilterMode, Settings};
+use atuin_client::{
+    database::{current_context, Database},
+    history::History,
+    settings::{FilterMode, Settings},
+};
 
 #[derive(Parser)]
 #[clap(infer_subcommands = true)]

--- a/src/command/client/sync.rs
+++ b/src/command/client/sync.rs
@@ -1,8 +1,7 @@
-use atuin_client::database::Database;
 use clap::Subcommand;
 use eyre::{Result, WrapErr};
 
-use atuin_client::settings::Settings;
+use atuin_client::{database::Database, settings::Settings};
 
 mod login;
 mod logout;

--- a/src/command/client/sync/login.rs
+++ b/src/command/client/sync/login.rs
@@ -1,13 +1,11 @@
 use std::io;
 
-use atuin_common::api::LoginRequest;
-use clap::AppSettings;
-use clap::Parser;
+use clap::{AppSettings, Parser};
 use eyre::Result;
 use tokio::{fs::File, io::AsyncWriteExt};
 
-use atuin_client::api_client;
-use atuin_client::settings::Settings;
+use atuin_client::{api_client, settings::Settings};
+use atuin_common::api::LoginRequest;
 
 #[derive(Parser)]
 #[clap(setting(AppSettings::DeriveDisplayOrder))]

--- a/src/command/client/sync/register.rs
+++ b/src/command/client/sync/register.rs
@@ -1,10 +1,8 @@
-use clap::AppSettings;
-use clap::Parser;
+use clap::{AppSettings, Parser};
 use eyre::Result;
 use tokio::{fs::File, io::AsyncWriteExt};
 
-use atuin_client::api_client;
-use atuin_client::settings::Settings;
+use atuin_client::{api_client, settings::Settings};
 
 #[derive(Parser)]
 #[clap(setting(AppSettings::DeriveDisplayOrder))]

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -3,8 +3,7 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 use clap::Parser;
 use eyre::{Context, Result};
 
-use atuin_server::launch;
-use atuin_server::settings::Settings;
+use atuin_server::{launch, settings::Settings};
 
 #[derive(Parser)]
 #[clap(infer_subcommands = true)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 #![warn(clippy::pedantic, clippy::nursery)]
 #![allow(clippy::use_self)] // not 100% reliable
 
-use clap::AppSettings;
-use clap::Parser;
+use clap::{AppSettings, Parser};
 use eyre::Result;
 
 #[macro_use]


### PR DESCRIPTION
Imports sorted in order:
- stdlib
- external crates
- atuin/internal
