### PR TITLE
fix db range query

### DIFF
--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -260,8 +260,8 @@ impl Database for Sqlite {
         let res = sqlx::query(
             "select * from history where timestamp >= ?1 and timestamp <= ?2 order by timestamp asc",
         )
-        .bind(from)
-        .bind(to)
+        .bind(from.timestamp_nanos())
+        .bind(to.timestamp_nanos())
             .map(Self::query_history)
         .fetch_all(&self.pool)
         .await?;


### PR DESCRIPTION
I think chrono/sqlx was turning the datetime items into second based timestamps, whereas we store them in nano form