### PR TITLE
Adds stats summary 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 */target
 .env
 .idea/
+.vscode/

--- a/src/command/client.rs
+++ b/src/command/client.rs
@@ -29,7 +29,6 @@ pub enum Cmd {
     Import(import::Cmd),
 
     /// Calculate statistics for your history
-    #[clap(subcommand)]
     Stats(stats::Cmd),
 
     /// Output shell setup

--- a/src/command/client/stats.rs
+++ b/src/command/client/stats.rs
@@ -73,13 +73,12 @@ impl Cmd {
         } else {
             self.period.join(" ")
         };
-        let history = match words.as_str() {
-            "all" => db.list(FilterMode::Global, &context, None, false).await?,
-            _ => {
-                let start = parse_date_string(&words, Local::now(), settings.dialect.into())?;
-                let end = start + Duration::days(1);
-                db.range(start.into(), end.into()).await?
-            }
+        let history = if words.as_str() == "all" {
+            db.list(FilterMode::Global, &context, None, false).await?
+        } else {
+            let start = parse_date_string(&words, Local::now(), settings.dialect.into())?;
+            let end = start + Duration::days(1);
+            db.range(start.into(), end.into()).await?
         };
         compute_stats(&history)?;
         Ok(())

--- a/src/command/client/stats.rs
+++ b/src/command/client/stats.rs
@@ -14,12 +14,9 @@ use atuin_client::{
 
 #[derive(Parser)]
 #[clap(infer_subcommands = true)]
-pub enum Cmd {
-    /// Compute statistics for all of time
-    All,
-
-    /// Compute statistics for a single day
-    Day { words: Vec<String> },
+pub struct Cmd {
+    /// compute statistics for the specified period, leave blank for statistics since the beginning
+    period: Vec<String>,
 }
 
 fn compute_stats(history: &[History]) -> Result<()> {
@@ -28,7 +25,6 @@ fn compute_stats(history: &[History]) -> Result<()> {
     for i in history {
         *commands.entry(i.command.clone()).or_default() += 1;
     }
-
     let most_common_command = commands.iter().max_by(|a, b| a.1.cmp(b.1));
 
     if most_common_command.is_none() {
@@ -72,32 +68,23 @@ impl Cmd {
         settings: &Settings,
     ) -> Result<()> {
         let context = current_context();
-
-        match self {
-            Self::Day { words } => {
-                let words = if words.is_empty() {
-                    String::from("yesterday")
-                } else {
-                    words.join(" ")
-                };
-
+        let words = if self.period.is_empty() {
+            String::from("all")
+        } else {
+            self.period.join(" ")
+        };
+        let history: Vec<History>;
+        match words.as_str() {
+            "all" => {
+                history = db.list(FilterMode::Global, &context, None, false).await?;
+            }
+            _ => {
                 let start = parse_date_string(&words, Local::now(), settings.dialect.into())?;
                 let end = start + Duration::days(1);
-
-                let history = db.range(start.into(), end.into()).await?;
-
-                compute_stats(&history)?;
-
-                Ok(())
-            }
-
-            Self::All => {
-                let history = db.list(FilterMode::Global, &context, None, false).await?;
-
-                compute_stats(&history)?;
-
-                Ok(())
+                history = db.range(start.into(), end.into()).await?;
             }
         }
+        compute_stats(&history)?;
+        Ok(())
     }
 }

--- a/src/command/client/stats.rs
+++ b/src/command/client/stats.rs
@@ -73,10 +73,9 @@ impl Cmd {
         } else {
             self.period.join(" ")
         };
-        let history: Vec<History>;
-        match words.as_str() {
+        let history = match words.as_str() {
             "all" => {
-                history = db.list(FilterMode::Global, &context, None, false).await?;
+                db.list(FilterMode::Global, &context, None, false).await?
             }
             _ => {
                 let start = parse_date_string(&words, Local::now(), settings.dialect.into())?;

--- a/src/command/client/stats.rs
+++ b/src/command/client/stats.rs
@@ -74,15 +74,13 @@ impl Cmd {
             self.period.join(" ")
         };
         let history = match words.as_str() {
-            "all" => {
-                db.list(FilterMode::Global, &context, None, false).await?
-            }
+            "all" => db.list(FilterMode::Global, &context, None, false).await?,
             _ => {
                 let start = parse_date_string(&words, Local::now(), settings.dialect.into())?;
                 let end = start + Duration::days(1);
-                history = db.range(start.into(), end.into()).await?;
+                db.range(start.into(), end.into()).await?
             }
-        }
+        };
         compute_stats(&history)?;
         Ok(())
     }


### PR DESCRIPTION
Solves for #18 .

Modifies `stats` to work without sub command 

This currently works as;

```
> atuin stats
# equivalent to the earlier `atuin stats all`


> atuin stats last friday 
# displays  statistics for last friday

> atuin stats 01/01/2022
# displays  statistics for 1st Jan '22

> atuin stats monday
# displays  statistics for last monday

> atuin stats march
# displays stats for last march (2022-03-01 to 2022-03-31) , this currently displays for 1st March '22 only.
```

