### PR TITLE
Add local event log storage

### DIFF
--- a/atuin-client/migrations/20220505083406_create-events.sql
+++ b/atuin-client/migrations/20220505083406_create-events.sql
@@ -6,3 +6,6 @@ create table if not exists events (
 
 	history_id text not null
 );
+
+-- Ensure there is only ever one of each event type per history item
+create unique index history_event_idx ON events(event_type, history_id);

--- a/atuin-client/migrations/20220505083406_create-events.sql
+++ b/atuin-client/migrations/20220505083406_create-events.sql
@@ -1,0 +1,8 @@
+create table if not exists events (
+	id text primary key,
+	timestamp integer not null,
+	hostname text not null,
+	event_type text not null,
+
+	history_id text not null
+);

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -13,10 +13,10 @@ use sqlx::{
 };
 
 use super::{
+    event::{Event, EventType},
     history::History,
     ordering,
     settings::{FilterMode, SearchMode},
-    event::{Event, EventType},
 };
 
 pub struct Context {
@@ -62,6 +62,8 @@ pub trait Database: Send + Sync {
 
     async fn update(&self, h: &History) -> Result<()>;
     async fn history_count(&self) -> Result<i64>;
+    async fn event_count(&self) -> Result<i64>;
+    async fn merge_events(&self) -> Result<i64>;
 
     async fn first(&self) -> Result<History>;
     async fn last(&self) -> Result<History>;
@@ -326,6 +328,48 @@ impl Database for Sqlite {
         .await?;
 
         Ok(res)
+    }
+
+    async fn event_count(&self) -> Result<i64> {
+        let res: (i64,) = sqlx::query_as("select count(1) from events")
+            .fetch_one(&self.pool)
+            .await?;
+
+        Ok(res.0)
+    }
+
+    // Ensure that we have correctly merged the event log
+    async fn merge_events(&self) -> Result<i64> {
+        // Ensure that we do not have more history locally than we do events.
+        // We can think of history as the merged log of events. There should never be more history than
+        // events, and the only time this could happen is if someone is upgrading from an old Atuin version
+        // from before we stored events.
+        let history_count = self.history_count().await?;
+
+        if history_count > self.event_count().await? {
+            // We're just gonna load everything into memory here. That sucks, I know, sorry.
+            // But also even if you have a LOT of history that should be fine, and we're only going to be doing this once EVER.
+            let no_context = Context {
+                cwd: String::from(""),
+                session: String::from(""),
+                hostname: String::from(""),
+            };
+
+            // pass an empty context, because with global listing we don't care
+            let all_the_history = self
+                .list(FilterMode::Global, &no_context, None, false)
+                .await?;
+
+            let mut tx = self.pool.begin().await?;
+            for i in all_the_history.iter() {
+                // A CREATE for every single history item is to be expected.
+                let event = Event::new_create(i);
+                Self::save_event(&mut tx, &event).await?;
+            }
+            tx.commit().await?;
+        }
+
+        Ok(0)
     }
 
     async fn history_count(&self) -> Result<i64> {

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -121,7 +121,7 @@ impl Sqlite {
     async fn save_event(tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>, e: &Event) -> Result<()> {
         let event_type = match e.event_type {
             EventType::Create => "create",
-            EventType::Delete => "create",
+            EventType::Delete => "delete",
         };
 
         sqlx::query(

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -331,7 +331,7 @@ impl Database for Sqlite {
     }
 
     async fn event_count(&self) -> Result<i64> {
-        let res: (i64,) = sqlx::query_as("select count(1) from events")
+        let res: i64 = sqlx::query_scalar("select count(1) from events")
             .fetch_one(&self.pool)
             .await?;
 

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -335,7 +335,7 @@ impl Database for Sqlite {
             .fetch_one(&self.pool)
             .await?;
 
-        Ok(res.0)
+        Ok(res)
     }
 
     // Ensure that we have correctly merged the event log

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -345,17 +345,18 @@ impl Database for Sqlite {
         // events, and the only time this could happen is if someone is upgrading from an old Atuin version
         // from before we stored events.
         let history_count = self.history_count().await?;
+        let event_count = self.event_count().await?;
 
-        if history_count > self.event_count().await? {
-            // We're just gonna load everything into memory here. That sucks, I know, sorry.
-            // But also even if you have a LOT of history that should be fine, and we're only going to be doing this once EVER.
+        if history_count > event_count {
+            // pass an empty context, because with global listing we don't care
             let no_context = Context {
                 cwd: String::from(""),
                 session: String::from(""),
                 hostname: String::from(""),
             };
 
-            // pass an empty context, because with global listing we don't care
+            // We're just gonna load everything into memory here. That sucks, I know, sorry.
+            // But also even if you have a LOT of history that should be fine, and we're only going to be doing this once EVER.
             let all_the_history = self
                 .list(FilterMode::Global, &no_context, None, false)
                 .await?;

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -176,7 +176,7 @@ impl Sqlite {
 impl Database for Sqlite {
     async fn save(&mut self, h: &History) -> Result<()> {
         debug!("saving history to sqlite");
-        let event = Event::new_create(h).expect("failed to create event from history");
+        let event = Event::new_create(h);
 
         let mut tx = self.pool.begin().await?;
         Self::save_raw(&mut tx, h).await?;
@@ -192,7 +192,7 @@ impl Database for Sqlite {
         let mut tx = self.pool.begin().await?;
 
         for i in h {
-            let event = Event::new_create(i).expect("failed to create event from history");
+            let event = Event::new_create(i);
             Self::save_raw(&mut tx, i).await?;
             Self::save_event(&mut tx, &event).await?;
         }

--- a/atuin-client/src/event.rs
+++ b/atuin-client/src/event.rs
@@ -1,17 +1,15 @@
 use chrono::Utc;
-use serde::{Deserialize, Serialize};
 use eyre::Result;
+use serde::{Deserialize, Serialize};
 
-use atuin_common::utils::uuid_v4;
 use crate::history::History;
-
+use atuin_common::utils::uuid_v4;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum EventType {
     Create,
-    Delete
+    Delete,
 }
-
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, sqlx::FromRow)]
 pub struct Event {
@@ -20,31 +18,31 @@ pub struct Event {
     pub hostname: String,
     pub event_type: EventType,
 
-    pub history_id: String
+    pub history_id: String,
 }
 
 impl Event {
-    pub fn new_create(history: &History) -> Result<Event> {
-        Ok(Event {
+    pub fn new_create(history: &History) -> Event {
+        Event {
             id: uuid_v4(),
             timestamp: history.timestamp,
             hostname: history.hostname.clone(),
             event_type: EventType::Create,
 
             history_id: history.id.clone(),
-        })
+        }
     }
 
-    pub fn new_delete(history_id: &str) -> Result<Event> {
+    pub fn new_delete(history_id: &str) -> Event {
         let hostname = format!("{}:{}", whoami::hostname(), whoami::username());
 
-        Ok(Event {
+        Event {
             id: uuid_v4(),
             timestamp: chrono::Utc::now(),
             hostname,
             event_type: EventType::Create,
 
             history_id: history_id.to_string(),
-        })
+        }
     }
 }

--- a/atuin-client/src/event.rs
+++ b/atuin-client/src/event.rs
@@ -1,0 +1,50 @@
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use eyre::Result;
+
+use atuin_common::utils::uuid_v4;
+use crate::history::History;
+
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum EventType {
+    Create,
+    Delete
+}
+
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, sqlx::FromRow)]
+pub struct Event {
+    pub id: String,
+    pub timestamp: chrono::DateTime<Utc>,
+    pub hostname: String,
+    pub event_type: EventType,
+
+    pub data: String
+}
+
+impl Event {
+    pub fn new_create(history: &History) -> Result<Event> {
+        Ok(Event {
+            id: uuid_v4(),
+            timestamp: history.timestamp,
+            hostname: history.hostname.clone(),
+            event_type: EventType::Create,
+
+            data: serde_json::to_string(history)?,
+        })
+    }
+
+    pub fn new_delete(history_id: &str) -> Result<Event> {
+        let hostname = format!("{}:{}", whoami::hostname(), whoami::username());
+
+        Ok(Event {
+            id: uuid_v4(),
+            timestamp: chrono::Utc::now(),
+            hostname,
+            event_type: EventType::Create,
+
+            data: history_id.to_string(),
+        })
+    }
+}

--- a/atuin-client/src/event.rs
+++ b/atuin-client/src/event.rs
@@ -20,7 +20,7 @@ pub struct Event {
     pub hostname: String,
     pub event_type: EventType,
 
-    pub data: String
+    pub history_id: String
 }
 
 impl Event {
@@ -31,7 +31,7 @@ impl Event {
             hostname: history.hostname.clone(),
             event_type: EventType::Create,
 
-            data: serde_json::to_string(history)?,
+            history_id: history.id.clone(),
         })
     }
 
@@ -44,7 +44,7 @@ impl Event {
             hostname,
             event_type: EventType::Create,
 
-            data: history_id.to_string(),
+            history_id: history_id.to_string(),
         })
     }
 }

--- a/atuin-client/src/event.rs
+++ b/atuin-client/src/event.rs
@@ -1,17 +1,16 @@
 use chrono::Utc;
-use eyre::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::history::History;
 use atuin_common::utils::uuid_v4;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum EventType {
     Create,
     Delete,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, sqlx::FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, sqlx::FromRow)]
 pub struct Event {
     pub id: String,
     pub timestamp: chrono::DateTime<Utc>,

--- a/atuin-client/src/lib.rs
+++ b/atuin-client/src/lib.rs
@@ -15,3 +15,4 @@ pub mod history;
 pub mod import;
 pub mod ordering;
 pub mod settings;
+pub mod event;

--- a/atuin-client/src/lib.rs
+++ b/atuin-client/src/lib.rs
@@ -11,8 +11,8 @@ pub mod encryption;
 pub mod sync;
 
 pub mod database;
+pub mod event;
 pub mod history;
 pub mod import;
 pub mod ordering;
 pub mod settings;
-pub mod event;

--- a/atuin-client/src/sync.rs
+++ b/atuin-client/src/sync.rs
@@ -140,6 +140,8 @@ async fn sync_upload(
 }
 
 pub async fn sync(settings: &Settings, force: bool, db: &mut (impl Database + Send)) -> Result<()> {
+    db.merge_events().await?;
+
     let client = api_client::Client::new(
         &settings.sync_address,
         &settings.session_token,

--- a/atuin-common/src/api.rs
+++ b/atuin-common/src/api.rs
@@ -65,3 +65,32 @@ pub struct IndexResponse {
     pub homage: String,
     pub version: String,
 }
+
+// Doubled up with the history sync stuff, because atm we need to support BOTH.
+// People are still running old clients, and in some cases _very_ old clients.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum AddEventRequest {
+    Create(AddHistoryRequest),
+
+    Delete {
+        id: String,
+        timestamp: chrono::DateTime<Utc>,
+        hostname: chrono::DateTime<Utc>,
+
+        // When we delete a history item, we push up an event marking its client
+        // id as being deleted.
+        history_id: String,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SyncEventRequest {
+    pub sync_ts: chrono::DateTime<chrono::FixedOffset>,
+    pub event_ts: chrono::DateTime<chrono::FixedOffset>,
+    pub host: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SyncEventResponse {
+    pub events: Vec<String>,
+}

--- a/atuin-server/migrations/20220505082442_create-events.sql
+++ b/atuin-server/migrations/20220505082442_create-events.sql
@@ -8,7 +8,7 @@ create table events (
 	timestamp timestamp not null,   -- one of the few non-encrypted metadatas
 
 	event_type event_type,
-	data varchar(100000) not null,    -- store the actual history data, encrypted. I don't wanna know!
+	data text not null,    -- store the actual history data, encrypted. I don't wanna know!
 
 	created_at timestamp not null default current_timestamp
 );

--- a/atuin-server/migrations/20220505082442_create-events.sql
+++ b/atuin-server/migrations/20220505082442_create-events.sql
@@ -1,0 +1,14 @@
+create type event_type as enum ('create', 'delete');
+ 
+create table events (
+	id bigserial primary key,
+	client_id text not null unique, -- the client-generated ID
+	user_id bigserial not null,     -- allow multiple users
+	hostname text not null,         -- a unique identifier from the client (can be hashed, random, whatever)
+	timestamp timestamp not null,   -- one of the few non-encrypted metadatas
+
+	event_type event_type,
+	data varchar(100000) not null,    -- store the actual history data, encrypted. I don't wanna know!
+
+	created_at timestamp not null default current_timestamp
+);

--- a/src/command/client/history.rs
+++ b/src/command/client/history.rs
@@ -136,10 +136,8 @@ impl Cmd {
 
                 // It's better for atuin to silently fail here and attempt to
                 // store whatever is ran, than to throw an error to the terminal
-                let cwd = match env::current_dir() {
-                    Ok(dir) => dir.display().to_string(),
-                    Err(_) => String::from(""),
-                };
+                let cwd = env::current_dir()
+                    .map_or_else(|_| String::new(), |dir| dir.display().to_string());
 
                 let h = History::new(chrono::Utc::now(), command, cwd, -1, -1, None, None);
 

--- a/src/command/client/search/history_list.rs
+++ b/src/command/client/search/history_list.rs
@@ -35,14 +35,11 @@ impl<'a> StatefulWidget for HistoryList<'a> {
     type State = ListState;
 
     fn render(mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
-        let list_area = match self.block.take() {
-            Some(b) => {
-                let inner_area = b.inner(area);
-                b.render(area, buf);
-                inner_area
-            }
-            None => area,
-        };
+        let list_area = self.block.take().map_or(area, |b| {
+            let inner_area = b.inner(area);
+            b.render(area, buf);
+            inner_area
+        });
 
         if list_area.width < 1 || list_area.height < 1 || self.history.is_empty() {
             return;


### PR DESCRIPTION
Start storing an event log locally! 

This will allow us to eventually start syncing events, rather than pure history items.

When merging an event log, we will pair up CREATEs with DELETEs. If there is a pair, we won't create the history. If there is not a pair (and just a CREATE), then the item is created. I've also started on the server end of this, while I had the context in my head. Obviously it's no use just yet

I've been running this branch locally for a bit, and have had no issues.