### PR TITLE
Add ctrl-k and ctrl-j for up and down

### DIFF
--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -343,7 +343,7 @@ async fn key_handler(
 
             query_results(app, search_mode, db).await.unwrap();
         }
-        Key::Down | Key::Ctrl('n') => {
+        Key::Down | Key::Ctrl('n') | Key::Ctrl('j') => {
             let i = match app.results_state.selected() {
                 Some(i) => {
                     if i == 0 {
@@ -356,7 +356,7 @@ async fn key_handler(
             };
             app.results_state.select(Some(i));
         }
-        Key::Up | Key::Ctrl('p') => {
+        Key::Up | Key::Ctrl('p') | Key::Ctrl('k') => {
             let i = match app.results_state.selected() {
                 Some(i) => {
                     if i >= app.results.len() - 1 {

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -343,7 +343,7 @@ async fn key_handler(
 
             query_results(app, search_mode, db).await.unwrap();
         }
-        Key::Down | Key::Ctrl('n') | Key::Ctrl('j') => {
+        Key::Down | Key::Ctrl('n' | 'j') => {
             let i = match app.results_state.selected() {
                 Some(i) => {
                     if i == 0 {
@@ -356,7 +356,7 @@ async fn key_handler(
             };
             app.results_state.select(Some(i));
         }
-        Key::Up | Key::Ctrl('p') | Key::Ctrl('k') => {
+        Key::Up | Key::Ctrl('p' | 'k') => {
             let i = match app.results_state.selected() {
                 Some(i) => {
                     if i >= app.results.len() - 1 {


### PR DESCRIPTION
For folks coming from [fzf](https://github.com/junegunn/fzf), ctrl-k and ctrl-j would be great to have as options for up and down respectively in the interactive search.

Thanks for the project! This looks great and I'm excited to use it.