### PR TITLE
Build ARM docker image in GitHub Actions using QEMU

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -19,6 +19,9 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -51,6 +54,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
+
+# Ensure working C compile setup (not installed by default in arm64 images)
+RUN apt update && apt install build-essential -y
+
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 


### PR DESCRIPTION
This PR updates the GH Action docker workflow to cross-build the docker
image for ARM using QEMU.
This theoretically works but takes about 2.5 hours for a clean build,
which may or may not be tolerable for each commit on `main`.
An action run where the dependencies are already cached needs about 15
minutes with this PR.

Closes #269 