### PR TITLE
Allow to build atuin server without client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,14 @@ members = ["./atuin-client", "./atuin-server", "./atuin-common"]
 # TODO(conradludgate)
 # Currently, this keeps the same default built behaviour for v0.8
 # We should rethink this by the time we hit a new breaking change
-default = ["sync", "server"]
+default = ["client", "sync", "server"]
+client = ["atuin-client"]
 sync = ["atuin-client/sync"]
 server = ["atuin-server", "tracing-subscriber"]
 
 [dependencies]
 atuin-server = { path = "atuin-server", version = "0.9.1", optional = true }
-atuin-client = { path = "atuin-client", version = "0.9.1", default-features = false }
+atuin-client = { path = "atuin-client", version = "0.9.1", optional = true, default-features = false }
 atuin-common = { path = "atuin-common", version = "0.9.1" }
 
 log = "0.4"

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,6 +1,7 @@
 use clap::Subcommand;
 use eyre::Result;
 
+#[cfg(feature = "client")]
 mod client;
 
 #[cfg(feature = "server")]
@@ -9,6 +10,7 @@ mod server;
 #[derive(Subcommand)]
 #[clap(infer_subcommands = true)]
 pub enum AtuinCmd {
+    #[cfg(feature = "client")]
     #[clap(flatten)]
     Client(client::Cmd),
 
@@ -21,6 +23,7 @@ pub enum AtuinCmd {
 impl AtuinCmd {
     pub fn run(self) -> Result<()> {
         match self {
+            #[cfg(feature = "client")]
             Self::Client(client) => client.run(),
             #[cfg(feature = "server")]
             Self::Server(server) => server.run(),


### PR DESCRIPTION
I’m packaging atuin for Alpine Linux and I’m building the atuin client and server as separate binaries, provided in separate (sub)package.