### PR TITLE
Don't create config dir for server in default location if not needed

### DIFF
--- a/atuin-server/src/settings.rs
+++ b/atuin-server/src/settings.rs
@@ -17,15 +17,11 @@ pub struct Settings {
 
 impl Settings {
     pub fn new() -> Result<Self> {
-        let config_dir = atuin_common::utils::config_dir();
-        let config_dir = config_dir.as_path();
-
-        create_dir_all(config_dir)?;
-
         let mut config_file = if let Ok(p) = std::env::var("ATUIN_CONFIG_DIR") {
             PathBuf::from(p)
         } else {
             let mut config_file = PathBuf::new();
+            let config_dir = atuin_common::utils::config_dir();
             config_file.push(config_dir);
             config_file
         };
@@ -50,6 +46,7 @@ impl Settings {
             ))
         } else {
             let example_config = include_bytes!("../server.toml");
+            create_dir_all(config_file.parent().unwrap())?;
             let mut file = File::create(config_file)?;
             file.write_all(example_config)?;
 


### PR DESCRIPTION
...respect ATUIN_CONFIG_DIR.

The current behaviour is problematic when running atuin server as a
system service with config dir in /etc/atuin.