### PR TITLE
Implement cursor

### DIFF
--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -306,12 +306,12 @@ async fn key_handler(
                     .map_or(app.input.clone(), |h| h.command.clone()),
             );
         }
-        Key::Right | Key::Ctrl('h') => {
+        Key::Left | Key::Ctrl('h') => {
             if app.cursor_index != 0 {
                 app.cursor_index -= 1;
             }
         }
-        Key::Left | Key::Ctrl('l') => {
+        Key::Right | Key::Ctrl('l') => {
             if app.cursor_index < app.input.width() {
                 app.cursor_index += 1;
             }

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -495,7 +495,13 @@ fn draw<T: Backend>(f: &mut Frame<'_, T>, history_count: i64, app: &mut State) {
     );
     f.render_widget(input, chunks[2]);
 
-    let width = UnicodeWidthStr::width(app.input.chars().take(app.cursor_index).collect::<String>().as_str());
+    let width = UnicodeWidthStr::width(
+        app.input
+            .chars()
+            .take(app.cursor_index)
+            .collect::<String>()
+            .as_str(),
+    );
     f.set_cursor(
         // Put cursor past the end of the input text
         chunks[2].x + width as u16 + 1,
@@ -568,7 +574,13 @@ fn draw_compact<T: Backend>(f: &mut Frame<'_, T>, history_count: i64, app: &mut 
     app.render_results(f, chunks[1], Block::default());
     f.render_widget(input, chunks[2]);
 
-    let extra_width = UnicodeWidthStr::width(app.input.chars().take(app.cursor_index).collect::<String>().as_str()) + filter_mode.len();
+    let extra_width = UnicodeWidthStr::width(
+        app.input
+            .chars()
+            .take(app.cursor_index)
+            .collect::<String>()
+            .as_str(),
+    ) + filter_mode.len();
 
     f.set_cursor(
         // Put cursor past the end of the input text

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -328,17 +328,25 @@ async fn key_handler(
             query_results(app, search_mode, db).await.unwrap();
         }
         Key::Backspace => {
-            if app.cursor_index == 0 { return None; }
-            app.input.remove(app.cursor_index-1);
+            if app.cursor_index == 0 {
+                return None;
+            }
+            app.input.remove(app.cursor_index - 1);
             app.cursor_index -= 1;
             query_results(app, search_mode, db).await.unwrap();
         }
         Key::Ctrl('w') => {
             let mut stop_on_next_whitespace = false;
             loop {
-                if app.cursor_index == 0 { break; }
-                if app.input.chars().nth(app.cursor_index-1) == Some(' ') && stop_on_next_whitespace { break; }
-                if !app.input.remove(app.cursor_index-1).is_whitespace() {
+                if app.cursor_index == 0 {
+                    break;
+                }
+                if app.input.chars().nth(app.cursor_index - 1) == Some(' ')
+                    && stop_on_next_whitespace
+                {
+                    break;
+                }
+                if !app.input.remove(app.cursor_index - 1).is_whitespace() {
                     stop_on_next_whitespace = true;
                 }
                 app.cursor_index -= 1;

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -328,7 +328,8 @@ async fn key_handler(
             query_results(app, search_mode, db).await.unwrap();
         }
         Key::Backspace => {
-            app.input.remove(app.cursor_index);
+            if app.cursor_index == 0 { return None; }
+            app.input.remove(app.cursor_index-1);
             app.cursor_index -= 1;
             query_results(app, search_mode, db).await.unwrap();
         }
@@ -342,6 +343,7 @@ async fn key_handler(
                 }
                 app.cursor_index -= 1;
             }
+            query_results(app, search_mode, db).await.unwrap();
         }
         Key::Ctrl('u') => {
             app.input = String::from("");

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -300,9 +300,10 @@ fn remove_char_from_input(app: &mut State, i: usize) -> char {
     result.push_str(&get_input_suffix(app, i));
     let c = app.input.chars().nth(i - 1).unwrap();
     app.input = result;
-    return c;
+    c
 }
 
+#[allow(clippy::too_many_lines)]
 async fn key_handler(
     input: Key,
     search_mode: SearchMode,


### PR DESCRIPTION
#### This PR implements a cursor, meaning you can move around in the input field, delete or add chars in the middle, etc.

<h3 align="center"><img src="https://user-images.githubusercontent.com/47924309/168497142-b35d562b-e76a-4311-b7f1-939fadfe8fe9.gif" width="75%"/><br/><i>Demo</i></h3>

## Changes

I added a field called _cursor_index_ to the _State_ struct. Every function interacting with the user input now has to use this value, so it's not a trivial change.

I added the following keybinds:

- Control + w (delete back one word)
- Control + a (go to the beginning of the line)
- Control + e (go to the end of the line)

These are the default bash keybinds for these operations, adding more should be fairly simple.

I also modified what I believe to be all places in the _search.rs_ file affected by this, namely the other keybinds and the draw functions.

## Problems

### Arrow keys not recognised properly

For some reason, the _Key::Right_ and _Key::Left_ keybinds don't do anything. I looked at the termion docs, and it seems to be the correct value for the right and left arrow keys, but the events don't trigger for some reason. The up & down keys seem to work just fine.

For now, I did all my testing using the alternative vim-style keybinds. (Control + h/l)

### Text encoding

The input is a _String_, so it supports unicode. My current implementation only works properly with ASCII text.

I think unicode should be supported, which is why I'm creating this as a draft PR.

I don't think making it work with unicode would be too hard, but it might be a bit of a hassle, so I want to make sure this is something you're interested in merging first before working on it.

## Fixes

This would close #410