### PR TITLE
Add fish shell to key binding docs

### DIFF
--- a/docs/key-binding.md
+++ b/docs/key-binding.md
@@ -36,3 +36,13 @@ eval "$(atuin init bash)"
 # bind to ctrl-r, add any other bindings you want here too
 bind -x '"\C-r": __atuin_history'
 ```
+# fish
+
+```
+set -gx ATUIN_NOBIND "true"
+atuin init fish | source
+
+# bind to ctrl-r in normal and insert mode, add any other bindings you want here too
+bind \cr _atuin_search
+bind -M insert \cr _atuin_search
+```


### PR DESCRIPTION
Add the missing fish shell part into the documentation for ATUIN_NOBIND.

Binding to up is pretty problematic in fish, as if you want to navigate the pager for auto-suggestions, you tend to get a bit stuck.