### PR TITLE
Improve default fish keybindings

### DIFF
--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -20,16 +20,41 @@ function _atuin_search
     end
 end
 
+function _atuin_suppress_tui
+    set -gx ATUIN_SUPPRESS_TUI "true"
+end
+
+function _atuin_unsuppress_tui
+    set -ge ATUIN_SUPPRESS_TUI
+end
+
+function _atuin_bind_up
+    if test -z $ATUIN_SUPPRESS_TUI
+        _atuin_search
+    else
+        up-or-search
+    end
+end
+
 if test -z $ATUIN_NOBIND
     bind \cr _atuin_search
-    bind -k up _atuin_search
-    bind \eOA _atuin_search
-    bind \e\[A _atuin_search
+    bind -k up _atuin_bind_up
+    bind \eOA _atuin_bind_up
+    bind \e\[A _atuin_bind_up
+    bind \t 'commandline -f complete && _atuin_suppress_tui'
+    bind \e 'commandline -f cancel && _atuin_unsuppress_tui'
+    bind \r 'commandline -f execute && _atuin_unsuppress_tui'
+    bind \n 'commandline -f execute && _atuin_unsuppress_tui'
+
 
     if bind -M insert > /dev/null 2>&1
         bind -M insert \cr _atuin_search
-        bind -M insert -k up _atuin_search
-        bind -M insert \eOA _atuin_search
-        bind -M insert \e\[A _atuin_search
+        bind -M insert -k up _atuin_bind_up
+        bind -M insert \eOA _atuin_bind_up
+        bind -M insert \e\[A _atuin_bind_up
+        bind -M insert \t 'commandline -f complete && _atuin_suppress_tui'
+        bind -M insert \e 'commandline -f cancel && _atuin_unsuppress_tui'
+        bind -M insert \r 'commandline -f execute && _atuin_unsuppress_tui'
+        bind -M insert \n 'commandline -f execute && _atuin_unsuppress_tui'
     end
 end


### PR DESCRIPTION
Binding on "up" can conflict with the default fish keybindings as when in tab-completion mode, you are supposed to be able to use arrow keys to navigate the grid of suggestions, however pressing "up" will open the tui instead.

This attempts to work around it by tracking when the user is probably in a tab completion mode by setting a variable that we use to determine whether to open atuin or perform the default fish up action

This should partially address the issues raised in #419 