### PR TITLE
Release v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "atuin"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "atuin-client",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "serde",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "atuin-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 edition = "2018"
 rust-version = "1.59"
@@ -39,9 +39,9 @@ sync = ["atuin-client/sync"]
 server = ["atuin-server", "tracing-subscriber"]
 
 [dependencies]
-atuin-server = { path = "atuin-server", version = "0.9.1", optional = true }
-atuin-client = { path = "atuin-client", version = "0.9.1", optional = true, default-features = false }
-atuin-common = { path = "atuin-common", version = "0.9.1" }
+atuin-server = { path = "atuin-server", version = "0.10.0", optional = true }
+atuin-client = { path = "atuin-client", version = "0.10.0", optional = true, default-features = false }
+atuin-common = { path = "atuin-common", version = "0.10.0" }
 
 log = "0.4"
 pretty_env_logger = "0.4"

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-client"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 edition = "2018"
 license = "MIT"
@@ -23,7 +23,7 @@ sync = [
 ]
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "0.9.1" }
+atuin-common = { path = "../atuin-common", version = "0.10.0" }
 
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }

--- a/atuin-common/Cargo.toml
+++ b/atuin-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-common"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 edition = "2018"
 license = "MIT"

--- a/atuin-server/Cargo.toml
+++ b/atuin-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-server"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 edition = "2018"
 license = "MIT"
@@ -9,7 +9,7 @@ homepage = "https://atuin.sh"
 repository = "https://github.com/ellie/atuin"
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "0.9.1" }
+atuin-common = { path = "../atuin-common", version = "0.10.0" }
 
 tracing = "0.1"
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
06ac9587 Show current version on server index (#436)
706b1aff Disable ARM docker builds (#438)
f2abc23a Update README.md
3c2b0550 Noyez fix dir hostname utf8 (#430)
3f5350de [feature] Add scroll wheel support to interactive history search (#435)
dcdde225 Fix text outline for dark mode
9ac0c60c Implement cursor (#412)
119ab9e0 Adds password prompt for register and login (#424)
e5df809d Noyez zsh histdb import (#393)
b08e2543 Improve default fish keybindings (#420)
4096c6ee Update README.md
cd2a3ab7 Add fish shell to key binding docs (#418)
b2782110 Bump clap_complete from 3.1.3 to 3.1.4 (#397)
ee66c0a1 Bump axum from 0.5.5 to 0.5.6 (#415)
4297e263 Bump tokio from 1.18.1 to 1.18.2 (#396)
dbd9ca53 Bump clap from 3.1.16 to 3.1.18 (#401)
a7c9d19d Bump tower-http from 0.3.2 to 0.3.3 (#399)
3b79f686 Bump axum from 0.5.4 to 0.5.5 (#402)
f3407710 Cleanup dependencies – disable unnecessary or unused features (#407)
ab294cde Don't pollute shell environment - remove 'id' variable (#408)
14b30606 Allow to build atuin server without client (#404)
5e4e8d11 Don't create config dir for server in default location if not needed (#406)
b7946cc9 Update Chinese version README.md (#403)
e0291f67 Update README.md
301190e4 Build ARM docker image in GitHub Actions using QEMU (#400)
1d030b9d Importer V3 (#395)
d3a4ff95 Bump clap from 3.1.15 to 3.1.16 (#392)
e9d2ec4b Add ctrl-k and ctrl-j for up and down (#394)
25afb5b2 Bump serde_json from 1.0.80 to 1.0.81 (#387)
4a839dab Adds stats summary  (#384)
7a394b01 Bump serde from 1.0.136 to 1.0.137 (#375)
edd3f812 Bump clap_complete from 3.1.2 to 3.1.3 (#377)
d85d03d9 Bump log from 0.4.16 to 0.4.17 (#382)
dc3b7ef5 Bump tokio from 1.18.0 to 1.18.1 (#383)
12440c1c Bump serde_json from 1.0.79 to 1.0.80 (#376)
731042f4 Bump tower-http from 0.3.1 to 0.3.2 (#378)
82505e61 Bump clap from 3.1.12 to 3.1.15 (#381)
e05c19d0 Add Chinese documentation translation & Fix spelling mistakes (#373)
6e280e25 Add Russian documentation translation (#365)
40efdd11 Bump http from 0.2.6 to 0.2.7 (#368)
8bc5becc Bump tower-http from 0.3.0 to 0.3.1 (#367)
172ac8db Create FUNDING.yml
7cdd00b5 Bump tokio from 1.17.0 to 1.18.0 (#357)
9d2e9ea1 Search: Allow specifiying the limited of returned entries (#364)
93ab4e78 ignore JetBrains IDEs, tidy-up imports (#348)
2cb4cb39 Bump axum from 0.5.3 to 0.5.4 (#355)
796644e2 Add created_at column to users (#354)
f8233bcb SQLx cannot run this migration OK (#353)
d8ef5dd9 fix db range query (#351)
5926ea64 fix import auto for bash (#352)
43d299fd bump tui (#346)
8ac6571b Remove all select * from the server queries (#347)
4030de4b Add btree index on history table (#345)
b692e0ce Bump tower-http from 0.2.5 to 0.3.0 (#343)
3680f4ac Bump clap from 3.1.11 to 3.1.12 (#342)
7f5310a1 history list (#340)