### PR TITLE
Enhancements to bash init script

### DIFF
--- a/src/shell/atuin.bash
+++ b/src/shell/atuin.bash
@@ -2,8 +2,8 @@ ATUIN_SESSION=$(atuin uuid)
 export ATUIN_SESSION
 
 _atuin_preexec() {
-	local id; id=$(atuin history start "$1")
-    export ATUIN_HISTORY_ID="$id"
+    local id; id=$(atuin history start "$1")
+    export ATUIN_HISTORY_ID="${id}"
 }
 
 _atuin_precmd() {
@@ -11,20 +11,18 @@ _atuin_precmd() {
 
     [[ -z "${ATUIN_HISTORY_ID}" ]] && return
 
-    (RUST_LOG=error atuin history end "$ATUIN_HISTORY_ID" --exit $EXIT &) > /dev/null 2>&1
+    (RUST_LOG=error atuin history end "${ATUIN_HISTORY_ID}" --exit "${EXIT}" &) > /dev/null 2>&1
 }
-
 
 __atuin_history ()
 {
     tput rmkx
-    HISTORY="$(RUST_LOG=error atuin search -i "$BUFFER" 3>&1 1>&2 2>&3)"
+    HISTORY="$(RUST_LOG=error atuin search -i "${READLINE_LINE}" 3>&1 1>&2 2>&3)"
     tput smkx
 
     READLINE_LINE=${HISTORY}
     READLINE_POINT=${#READLINE_LINE}
 }
-
 
 if [[ -n "${BLE_VERSION-}" ]]; then
     blehook PRECMD-+=_atuin_precmd
@@ -34,6 +32,8 @@ else
     preexec_functions+=(_atuin_preexec)
 fi
 
-if [[ -z $ATUIN_NOBIND ]]; then
+if [[ -z ${ATUIN_NOBIND} ]]; then
     bind -x '"\C-r": __atuin_history'
+    bind -x '"\e[A": __atuin_history'
+    bind -x '"\eOA": __atuin_history'
 fi


### PR DESCRIPTION
 - Pass READLINE_LINE so current bash buffer is provided
 - Bind `up` to atuin as is done for zsh/fish and mentioned in docs
 - Clean up indentation/newlines
 - Follow optional shellcheck "style" checks for escaping/encapsulating

Fixes #428
Fixes #431