### PR TITLE
Add configurable history length

### DIFF
--- a/atuin-server/migrations/20220610074049_history-length.sql
+++ b/atuin-server/migrations/20220610074049_history-length.sql
@@ -1,0 +1,2 @@
+-- Add migration script here
+alter table history alter column data type text;

--- a/atuin-server/src/database.rs
+++ b/atuin-server/src/database.rs
@@ -4,14 +4,14 @@ use async_trait::async_trait;
 use chrono::{Datelike, TimeZone};
 use chronoutil::RelativeDuration;
 use sqlx::{postgres::PgPoolOptions, Result};
-use tracing::{debug, warn, instrument};
+use tracing::{debug, instrument, warn};
 
 use super::{
     calendar::{TimePeriod, TimePeriodInfo},
     models::{History, NewHistory, NewSession, NewUser, Session, User},
 };
-use crate::settings::HISTORY_PAGE_SIZE;
 use crate::settings::Settings;
+use crate::settings::HISTORY_PAGE_SIZE;
 
 use atuin_common::utils::get_days_from_month;
 
@@ -254,11 +254,17 @@ impl Database for Postgres {
             let hostname: &str = &i.hostname;
             let data: &str = &i.data;
 
-            if data.len() > self.settings.max_history_length && self.settings.max_history_length != 0 {
+            if data.len() > self.settings.max_history_length
+                && self.settings.max_history_length != 0
+            {
                 // Don't return an error here. We want to insert as much of the
                 // history list as we can, so log the error and continue going.
-                
-                warn!("history too long, got length {}, max {}", data.len(), self.settings.max_history_length);
+
+                warn!(
+                    "history too long, got length {}, max {}",
+                    data.len(),
+                    self.settings.max_history_length
+                );
 
                 continue;
             }

--- a/atuin-server/src/database.rs
+++ b/atuin-server/src/database.rs
@@ -4,13 +4,14 @@ use async_trait::async_trait;
 use chrono::{Datelike, TimeZone};
 use chronoutil::RelativeDuration;
 use sqlx::{postgres::PgPoolOptions, Result};
-use tracing::{debug, instrument};
+use tracing::{debug, warn, instrument};
 
 use super::{
     calendar::{TimePeriod, TimePeriodInfo},
     models::{History, NewHistory, NewSession, NewUser, Session, User},
 };
 use crate::settings::HISTORY_PAGE_SIZE;
+use crate::settings::Settings;
 
 use atuin_common::utils::get_days_from_month;
 
@@ -61,18 +62,19 @@ pub trait Database {
 #[derive(Clone)]
 pub struct Postgres {
     pool: sqlx::Pool<sqlx::postgres::Postgres>,
+    settings: Settings,
 }
 
 impl Postgres {
-    pub async fn new(uri: &str) -> Result<Self> {
+    pub async fn new(settings: Settings) -> Result<Self> {
         let pool = PgPoolOptions::new()
             .max_connections(100)
-            .connect(uri)
+            .connect(settings.db_uri.as_str())
             .await?;
 
         sqlx::migrate!("./migrations").run(&pool).await?;
 
-        Ok(Self { pool })
+        Ok(Self { pool, settings })
     }
 }
 
@@ -251,6 +253,15 @@ impl Database for Postgres {
             let client_id: &str = &i.client_id;
             let hostname: &str = &i.hostname;
             let data: &str = &i.data;
+
+            if data.len() > self.settings.max_history_length && self.settings.max_history_length != 0 {
+                // Don't return an error here. We want to insert as much of the
+                // history list as we can, so log the error and continue going.
+                
+                warn!("history too long, got length {}, max {}", data.len(), self.settings.max_history_length);
+
+                continue;
+            }
 
             sqlx::query(
                 "insert into history

--- a/atuin-server/src/lib.rs
+++ b/atuin-server/src/lib.rs
@@ -19,7 +19,7 @@ pub mod settings;
 pub async fn launch(settings: Settings, host: String, port: u16) -> Result<()> {
     let host = host.parse::<IpAddr>()?;
 
-    let postgres = Postgres::new(settings.db_uri.as_str())
+    let postgres = Postgres::new(settings.clone())
         .await
         .wrap_err_with(|| format!("failed to connect to db: {}", settings.db_uri))?;
 

--- a/atuin-server/src/settings.rs
+++ b/atuin-server/src/settings.rs
@@ -13,6 +13,7 @@ pub struct Settings {
     pub port: u16,
     pub db_uri: String,
     pub open_registration: bool,
+    pub max_history_length: usize,
 }
 
 impl Settings {
@@ -33,6 +34,7 @@ impl Settings {
             .set_default("host", "127.0.0.1")?
             .set_default("port", 8888)?
             .set_default("open_registration", false)?
+            .set_default("max_history_length", 8192)?
             .add_source(
                 Environment::with_prefix("atuin")
                     .prefix_separator("_")


### PR DESCRIPTION
This allows servers to decide the max length of each history item they
want to store! Some users might have much larger history lines than
others.

This setting can be set to 0 to allow for unlimited history length. This
is not recommended for a public server install, but for a private one it
can work nicely.

Resolves #416