### PR TITLE
Add binstall configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ homepage = "https://atuin.sh"
 repository = "https://github.com/ellie/atuin"
 readme = "README.md"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version  }-{ target }.tar.gz"
+bin-dir = "{ name }-v{ version }-{ target }/{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
 [package.metadata.deb]
 maintainer = "Ellie Huxtable <ellie@elliehuxtable.com>"
 copyright = "2021, Ellie Huxtable <ellie@elliehuxtable.com>"


### PR DESCRIPTION
This adds support for installation via [binstall](https://github.com/ryankurte/cargo-binstall). It's simply a set of configuration settings that allows the binstall tool to locate precompiled binaries in the existing GitHub releases. This allows users of binstall to skip the compilation step if a prebuilt binary is available.