### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,14 +192,6 @@ And then follow [the shell setup](#shell-plugin)
 Once the binary is installed, the shell plugin requires installing. If you use
 the install script, this should all be done for you!
 
-### Fig
-
-[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
-
-Install `atuin` shell plugin in zsh, bash, or fish with just one click. 
-
-<a href="https://fig.io/plugins/other/atuin" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
-
 ### zsh
 
 ```
@@ -236,6 +228,12 @@ atuin init fish | source
 ```
 
 to your `is-interactive` block in your `~/.config/fish/config.fish` file
+  
+### Fig
+
+Install `atuin` shell plugin in zsh, bash, or fish with [Fig](https://fig.io) in one click. 
+
+<a href="https://fig.io/plugins/other/atuin" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 
 ## ...what's with the name?
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ And then follow [the shell setup](#shell-plugin)
 Once the binary is installed, the shell plugin requires installing. If you use
 the install script, this should all be done for you!
 
+### Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `atuin` shell plugin in zsh, bash, or fish with just one click. 
+
+<a href="https://fig.io/plugins/other/atuin" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### zsh
 
 ```


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

`atuin` is already listed in the store so we'd love to have it listed as a download method on your README.

Thanks so much and please let me know if you have any questions!