### PR TITLE
Exit with return code 1 when no results are found in `atuin search` command

### DIFF
--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -91,7 +91,7 @@ impl Cmd {
             eprintln!("{}", item);
         } else {
             let list_mode = ListMode::from_flags(self.human, self.cmd_only);
-            run_non_interactive(
+            let entries = run_non_interactive(
                 settings,
                 list_mode,
                 self.cwd,
@@ -105,6 +105,9 @@ impl Cmd {
                 db,
             )
             .await?;
+            if entries == 0 {
+                std::process::exit(1)
+            }
         };
         Ok(())
     }
@@ -672,7 +675,7 @@ async fn run_non_interactive(
     limit: Option<i64>,
     query: &[String],
     db: &mut impl Database,
-) -> Result<()> {
+) -> Result<usize> {
     let dir = if cwd.as_deref() == Some(".") {
         let current = std::env::current_dir()?;
         let current = current.as_os_str();
@@ -754,5 +757,5 @@ async fn run_non_interactive(
         .collect();
 
     super::history::print_list(&results, list_mode);
-    Ok(())
+    Ok(results.len()) 
 }

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -757,5 +757,5 @@ async fn run_non_interactive(
         .collect();
 
     super::history::print_list(&results, list_mode);
-    Ok(results.len()) 
+    Ok(results.len())
 }


### PR DESCRIPTION
This enables scripts to more easily detect when no results are found.
