### PR TITLE
Add index for interactive search

### DIFF
--- a/atuin-client/migrations/20220806155627_interactive_search_index.sql
+++ b/atuin-client/migrations/20220806155627_interactive_search_index.sql
@@ -1,0 +1,6 @@
+-- Interactive search filters by command then by the max(timestamp) for that
+-- command. Create an index that covers those
+create index if not exists idx_history_command_timestamp on history(
+	command,
+	timestamp
+);


### PR DESCRIPTION
Related #475 (cc @Byron)

This PR adds an index intended to improve the query for interactive search

I was able to artificially create bad startup times for `atuin search --interactive` by adding several thousand entries to my history with the same command. This stresses the `max(timestamp)` for a given command because there is no index to relate timestamps to their respective commands. With this I was able to reproduce an over 2 second startup time which became well under 1 second after this change

Opening as a draft because I want to see if this impact is noticeable for more organic histories. You can test by manually creating this index on your `history.db`

NOTE: for local testing your system installed `atuin` will get angry if extra migrations are applied that it doesn't recognize. You can still manually add the index using `sqlite3` and it won't notice, but running `atuin` built from this PR while still having an older version installed still can give

```text
Error: migration 20220806155627 was previously applied but is missing in the resolved migrations

Caused by:
    migration 20220806155627 was previously applied but is missing in the resolved migrations

Location:
    src/command/client.rs:68:22
```