### PR TITLE
Add dockerfile in dependabot scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Regarding the discussions in https://github.com/ellie/atuin/pull/506, I suggest to add the dockerfile in dependabot's scope.

It will create more PRs but will help keeping everything up to date :)