### PR TITLE
Fix atuin crashing on commands that start with --

### DIFF
--- a/src/shell/atuin.bash
+++ b/src/shell/atuin.bash
@@ -2,7 +2,7 @@ ATUIN_SESSION=$(atuin uuid)
 export ATUIN_SESSION
 
 _atuin_preexec() {
-    local id; id=$(atuin history start "$1")
+    local id; id=$(atuin history start -- "$1")
     export ATUIN_HISTORY_ID="${id}"
 }
 
@@ -11,13 +11,13 @@ _atuin_precmd() {
 
     [[ -z "${ATUIN_HISTORY_ID}" ]] && return
 
-    (RUST_LOG=error atuin history end "${ATUIN_HISTORY_ID}" --exit "${EXIT}" &) > /dev/null 2>&1
+    (RUST_LOG=error atuin history end --exit "${EXIT}" -- "${ATUIN_HISTORY_ID}" &) > /dev/null 2>&1
 }
 
 __atuin_history ()
 {
     tput rmkx
-    HISTORY="$(RUST_LOG=error atuin search -i "${READLINE_LINE}" 3>&1 1>&2 2>&3)"
+    HISTORY="$(RUST_LOG=error atuin search -i -- "${READLINE_LINE}" 3>&1 1>&2 2>&3)"
     tput smkx
 
     READLINE_LINE=${HISTORY}

--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -1,19 +1,19 @@
 set -gx ATUIN_SESSION (atuin uuid)
 
 function _atuin_preexec --on-event fish_preexec
-    set -gx ATUIN_HISTORY_ID (atuin history start "$argv[1]")
+    set -gx ATUIN_HISTORY_ID (atuin history start -- "$argv[1]")
 end
 
 function _atuin_postexec --on-event fish_postexec
     set s $status
     if test -n "$ATUIN_HISTORY_ID"
-        RUST_LOG=error atuin history end $ATUIN_HISTORY_ID --exit $s &
+        RUST_LOG=error atuin history end --exit $s -- $ATUIN_HISTORY_ID &
         disown
     end
 end
 
 function _atuin_search
-    set h (RUST_LOG=error atuin search -i (commandline -b) 3>&1 1>&2 2>&3)
+    set h (RUST_LOG=error atuin search -i -- (commandline -b) 3>&1 1>&2 2>&3)
     commandline -f repaint
     if test -n "$h"
         commandline -r $h

--- a/src/shell/atuin.zsh
+++ b/src/shell/atuin.zsh
@@ -13,7 +13,7 @@ export ATUIN_SESSION=$(atuin uuid)
 export ATUIN_HISTORY="atuin history list"
 
 _atuin_preexec(){
-	local id; id=$(atuin history start "$1")
+	local id; id=$(atuin history start -- "$1")
 	export ATUIN_HISTORY_ID="$id"
 }
 
@@ -23,7 +23,7 @@ _atuin_precmd(){
 	[[ -z "${ATUIN_HISTORY_ID}" ]] && return
 
 
-	(RUST_LOG=error atuin history end $ATUIN_HISTORY_ID --exit $EXIT &) > /dev/null 2>&1
+	(RUST_LOG=error atuin history end --exit $EXIT -- $ATUIN_HISTORY_ID &) > /dev/null 2>&1
 }
 
 _atuin_search(){
@@ -34,7 +34,7 @@ _atuin_search(){
 	echoti rmkx
 	# swap stderr and stdout, so that the tui stuff works
 	# TODO: not this
-	output=$(RUST_LOG=error atuin search -i $BUFFER 3>&1 1>&2 2>&3)
+	output=$(RUST_LOG=error atuin search -i -- $BUFFER 3>&1 1>&2 2>&3)
 	echoti smkx
 
 	if [[ -n $output ]] ; then


### PR DESCRIPTION
The use of `--` in the shell scripts prevents clap attempting to parse
the command name as a flag, in the case that it starts with `--`.

Previously, atuin would crash with the following error, if a command starting with `--` is used:

```shell
jamie@chronos (zsh) in atuin on  fix-double-dash via 🦀 v1.63.0 within  rust-nix-shell
<I> ➜ --example
error: Found argument '--example' which wasn't expected, or isn't valid in this context

	If you tried to supply `--example` as a value rather than a flag, use `-- --example`

USAGE:
    atuin history start [COMMAND]...

For more information try --help

```