### PR TITLE
Fix compatability with fish vi key bindings

### DIFF
--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -20,19 +20,11 @@ function _atuin_search
     end
 end
 
-function _atuin_suppress_tui
-    set -gx ATUIN_SUPPRESS_TUI "true"
-end
-
-function _atuin_unsuppress_tui
-    set -ge ATUIN_SUPPRESS_TUI
-end
-
 function _atuin_bind_up
-    if test -z $ATUIN_SUPPRESS_TUI
-        _atuin_search
-    else
+    if commandline -P
         up-or-search
+    else
+        _atuin_search
     end
 end
 
@@ -41,10 +33,6 @@ if test -z $ATUIN_NOBIND
     bind -k up _atuin_bind_up
     bind \eOA _atuin_bind_up
     bind \e\[A _atuin_bind_up
-    bind \t 'commandline -f complete && _atuin_suppress_tui'
-    bind \e 'commandline -f cancel && _atuin_unsuppress_tui'
-    bind \r 'commandline -f execute && _atuin_unsuppress_tui'
-    bind \n 'commandline -f execute && _atuin_unsuppress_tui'
 
 
     if bind -M insert > /dev/null 2>&1
@@ -52,9 +40,5 @@ if test -z $ATUIN_NOBIND
         bind -M insert -k up _atuin_bind_up
         bind -M insert \eOA _atuin_bind_up
         bind -M insert \e\[A _atuin_bind_up
-        bind -M insert \t 'commandline -f complete && _atuin_suppress_tui'
-        bind -M insert \e 'commandline -f cancel && _atuin_unsuppress_tui'
-        bind -M insert \r 'commandline -f execute && _atuin_unsuppress_tui'
-        bind -M insert \n 'commandline -f execute && _atuin_unsuppress_tui'
     end
 end


### PR DESCRIPTION
PR #420 addressed the existence of pagination in a fish prompt by trying to track when pagination was enabled and disabled. This introduced atuin-specific bindings for common keys: `\t`, `\e`, `\r`, and `\n` which export a variable and informs the `_autiun_search` function to not show the TUI.

Fish has a commandline function that will instead tell you whether pagination is enabled so the user doesn't need to keep track of that state. This PR uses this function, `commandline -P` to replace the prior TUI supression scheme. Removing these extra function calls allows us to remove the additional bindings which were breaking fish vi key bindings.

Replacing the value for `bind -M insert \e` completely breaks vi mode by blocking the user from exiting insert mode. By removing these extra binds, this PR restores fish vi mode compatability.