### PR TITLE
Allow stateless commands to be run without config/database

### DIFF
--- a/src/command/client.rs
+++ b/src/command/client.rs
@@ -1,24 +1,21 @@
 use std::path::PathBuf;
 
-use clap::{CommandFactory, Subcommand};
-use clap_complete::{generate, generate_to, Shell};
+use clap::Subcommand;
 use eyre::{Result, WrapErr};
 
 use atuin_client::{database::Sqlite, settings::Settings};
-use atuin_common::utils::uuid_v4;
 
 #[cfg(feature = "sync")]
 mod sync;
 
 mod history;
 mod import;
-mod init;
 mod search;
 mod stats;
 
 #[derive(Subcommand)]
 #[clap(infer_subcommands = true)]
-pub enum StatefulCmd {
+pub enum Cmd {
     /// Manipulate shell history
     #[clap(subcommand)]
     History(history::Cmd),
@@ -38,32 +35,8 @@ pub enum StatefulCmd {
     Sync(sync::Cmd),
 }
 
-#[derive(Subcommand)]
-#[clap(infer_subcommands = true)]
-pub enum Cmd {
-    /// Output shell setup
-    #[clap(subcommand)]
-    Init(init::Cmd),
-
-    #[clap(flatten)]
-    Stateful(StatefulCmd),
-
-    /// Generate a UUID
-    Uuid,
-
-    /// Generate shell completions
-    GenCompletions {
-        /// Set the shell for generating completions
-        #[clap(long, short)]
-        shell: Shell,
-
-        /// Set the output directory
-        #[clap(long, short)]
-        out_dir: Option<String>,
-    },
-}
-
-impl StatefulCmd {
+impl Cmd {
+    #[tokio::main(flavor = "current_thread")]
     pub async fn run(self) -> Result<()> {
         let settings = Settings::new().wrap_err("could not load client settings")?;
 
@@ -77,44 +50,6 @@ impl StatefulCmd {
             Self::Search(search) => search.run(&mut db, &settings).await,
             #[cfg(feature = "sync")]
             Self::Sync(sync) => sync.run(settings, &mut db).await,
-        }
-    }
-}
-
-impl Cmd {
-    #[tokio::main(flavor = "current_thread")]
-    pub async fn run(self) -> Result<()> {
-        pretty_env_logger::init();
-
-        match self {
-            Self::Init(init) => {
-                init.run();
-                Ok(())
-            }
-            Self::Stateful(cmd) => cmd.run().await,
-            Self::Uuid => {
-                println!("{}", uuid_v4());
-                Ok(())
-            }
-            Self::GenCompletions { shell, out_dir } => {
-                let mut cli = crate::Atuin::command();
-
-                match out_dir {
-                    Some(out_dir) => {
-                        generate_to(shell, &mut cli, env!("CARGO_PKG_NAME"), &out_dir)?;
-                    }
-                    None => {
-                        generate(
-                            shell,
-                            &mut cli,
-                            env!("CARGO_PKG_NAME"),
-                            &mut std::io::stdout(),
-                        );
-                    }
-                }
-
-                Ok(())
-            }
         }
     }
 }

--- a/src/command/client.rs
+++ b/src/command/client.rs
@@ -18,7 +18,7 @@ mod stats;
 
 #[derive(Subcommand)]
 #[clap(infer_subcommands = true)]
-pub enum Cmd {
+pub enum StatefulCmd {
     /// Manipulate shell history
     #[clap(subcommand)]
     History(history::Cmd),
@@ -30,15 +30,26 @@ pub enum Cmd {
     /// Calculate statistics for your history
     Stats(stats::Cmd),
 
+    /// Interactive history search
+    Search(search::Cmd),
+
+    #[cfg(feature = "sync")]
+    #[clap(flatten)]
+    Sync(sync::Cmd),
+}
+
+#[derive(Subcommand)]
+#[clap(infer_subcommands = true)]
+pub enum Cmd {
     /// Output shell setup
     #[clap(subcommand)]
     Init(init::Cmd),
 
+    #[clap(flatten)]
+    Stateful(StatefulCmd),
+
     /// Generate a UUID
     Uuid,
-
-    /// Interactive history search
-    Search(search::Cmd),
 
     /// Generate shell completions
     GenCompletions {
@@ -50,17 +61,10 @@ pub enum Cmd {
         #[clap(long, short)]
         out_dir: Option<String>,
     },
-
-    #[cfg(feature = "sync")]
-    #[clap(flatten)]
-    Sync(sync::Cmd),
 }
 
-impl Cmd {
-    #[tokio::main(flavor = "current_thread")]
+impl StatefulCmd {
     pub async fn run(self) -> Result<()> {
-        pretty_env_logger::init();
-
         let settings = Settings::new().wrap_err("could not load client settings")?;
 
         let db_path = PathBuf::from(settings.db_path.as_str());
@@ -70,11 +74,24 @@ impl Cmd {
             Self::History(history) => history.run(&settings, &mut db).await,
             Self::Import(import) => import.run(&mut db).await,
             Self::Stats(stats) => stats.run(&mut db, &settings).await,
+            Self::Search(search) => search.run(&mut db, &settings).await,
+            #[cfg(feature = "sync")]
+            Self::Sync(sync) => sync.run(settings, &mut db).await,
+        }
+    }
+}
+
+impl Cmd {
+    #[tokio::main(flavor = "current_thread")]
+    pub async fn run(self) -> Result<()> {
+        pretty_env_logger::init();
+
+        match self {
             Self::Init(init) => {
                 init.run();
                 Ok(())
             }
-            Self::Search(search) => search.run(&mut db, &settings).await,
+            Self::Stateful(cmd) => cmd.run().await,
             Self::Uuid => {
                 println!("{}", uuid_v4());
                 Ok(())
@@ -98,8 +115,6 @@ impl Cmd {
 
                 Ok(())
             }
-            #[cfg(feature = "sync")]
-            Self::Sync(sync) => sync.run(settings, &mut db).await,
         }
     }
 }

--- a/src/command/client.rs
+++ b/src/command/client.rs
@@ -38,6 +38,8 @@ pub enum Cmd {
 impl Cmd {
     #[tokio::main(flavor = "current_thread")]
     pub async fn run(self) -> Result<()> {
+        pretty_env_logger::init();
+
         let settings = Settings::new().wrap_err("could not load client settings")?;
 
         let db_path = PathBuf::from(settings.db_path.as_str());

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -11,17 +11,17 @@ pub enum Cmd {
 }
 
 fn init_zsh() {
-    let full = include_str!("../../shell/atuin.zsh");
+    let full = include_str!("../shell/atuin.zsh");
     println!("{}", full);
 }
 
 fn init_bash() {
-    let full = include_str!("../../shell/atuin.bash");
+    let full = include_str!("../shell/atuin.bash");
     println!("{}", full);
 }
 
 fn init_fish() {
-    let full = include_str!("../../shell/atuin.fish");
+    let full = include_str!("../shell/atuin.fish");
     println!("{}", full);
 }
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -11,6 +11,7 @@ mod server;
 mod init;
 
 #[derive(Subcommand)]
+#[clap(infer_subcommands = true)]
 pub enum AtuinCmd {
     #[cfg(feature = "client")]
     #[clap(flatten)]

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,4 +1,5 @@
-use clap::Subcommand;
+use clap::{CommandFactory, Subcommand};
+use clap_complete::{generate, generate_to, Shell};
 use eyre::Result;
 
 #[cfg(feature = "client")]
@@ -7,8 +8,9 @@ mod client;
 #[cfg(feature = "server")]
 mod server;
 
+mod init;
+
 #[derive(Subcommand)]
-#[clap(infer_subcommands = true)]
 pub enum AtuinCmd {
     #[cfg(feature = "client")]
     #[clap(flatten)]
@@ -18,6 +20,24 @@ pub enum AtuinCmd {
     #[cfg(feature = "server")]
     #[clap(subcommand)]
     Server(server::Cmd),
+
+    /// Output shell setup
+    #[clap(subcommand)]
+    Init(init::Cmd),
+
+    /// Generate a UUID
+    Uuid,
+
+    /// Generate shell completions
+    GenCompletions {
+        /// Set the shell for generating completions
+        #[clap(long, short)]
+        shell: Shell,
+
+        /// Set the output directory
+        #[clap(long, short)]
+        out_dir: Option<String>,
+    },
 }
 
 impl AtuinCmd {
@@ -27,6 +47,33 @@ impl AtuinCmd {
             Self::Client(client) => client.run(),
             #[cfg(feature = "server")]
             Self::Server(server) => server.run(),
+            Self::Init(init) => {
+                init.run();
+                Ok(())
+            }
+            Self::Uuid => {
+                println!("{}", atuin_common::utils::uuid_v4());
+                Ok(())
+            }
+            Self::GenCompletions { shell, out_dir } => {
+                let mut cli = crate::Atuin::command();
+
+                match out_dir {
+                    Some(out_dir) => {
+                        generate_to(shell, &mut cli, env!("CARGO_PKG_NAME"), &out_dir)?;
+                    }
+                    None => {
+                        generate(
+                            shell,
+                            &mut cli,
+                            env!("CARGO_PKG_NAME"),
+                            &mut std::io::stdout(),
+                        );
+                    }
+                }
+
+                Ok(())
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where gen-completions fails in restricted build environments while trying to create a config directory.

Settings::new() and Sqlite::new() are currently run unconditionally for every client command, even if those commands don't need access to the settings or database. This would cause running ```atuin gen-completions``` in a restricted build environment to fail while trying to create a path to the config directory.

This PR splits the client commands into two subsets, one subset that requires access to the settings/database and one that does not. Settings::new and Sqlite::new are then only called for the subset of commands that need them.

I think this is the most elegant approach to solving this issue, the other alternative would have been to move the calls to Settings::new and Sqlite::new into the commands' individual run methods. The current approach avoids this code duplication and should be easily extensible in the future if necessary.

The use of clap::flatten on the stateful commands means the commandline interface doesn't change in a user-facing way.