### PR TITLE
Clear RBUFFER when accepting output from atuin

### DIFF
--- a/src/shell/atuin.zsh
+++ b/src/shell/atuin.zsh
@@ -38,6 +38,7 @@ _atuin_search(){
 	echoti smkx
 
 	if [[ -n $output ]] ; then
+		RBUFFER=""
 		LBUFFER=$output
 	fi
 


### PR DESCRIPTION
Since we pass $BUFFER to atuin search, retaining RBUFFER (the part of the buffer to the right of the cursor) on accepting a history replacement probably doesn't make sense. The advantage of setting RBUFFER and LBUFFER separately instead of setting BUFFER is that the cursor is positioned after the end of LBUFFER instead of remaining where it was before atuin was called.

Alternatively, _atuin_search() could pass $LBUFFER to atuin instead of $BUFFER which would allow the widget to replace parts of command lines (such as the initial parts of a shell pipeline), but I would prefer the default to replace the whole command line from the history.

A widget that only replaces parts of command lines could be added separately if there's interest in it, though users could always just add it themselves (I'm not sure how many users would want such a feature).