### PR TITLE
Add `style` to config.toml and config.md

### DIFF
--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -29,4 +29,4 @@
 
 ## which style to use
 ## possible values: auto, full, compact
-style = "auto"
+#style = "auto"

--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -26,3 +26,7 @@
 ## which search mode to use
 ## possible values: prefix, fulltext, fuzzy
 # search_mode = "prefix"
+
+## which style to use
+## possible values: auto, full, compact
+style = "auto"

--- a/docs/config.md
+++ b/docs/config.md
@@ -102,6 +102,20 @@ the search syntax [described below](#fuzzy-search-syntax).
 
 Defaults to "prefix"
 
+### `style`
+
+Which style to use. Possible values: `auto`, `full` and `compact`.
+
+- `compact`:
+
+![image](https://user-images.githubusercontent.com/1710904/161623659-4fec047f-ea4b-471c-9581-861d2eb701a9.png)
+
+- `full`:
+
+![image](https://user-images.githubusercontent.com/1710904/161623547-42afbfa7-a3ef-4820-bacd-fcaf1e324969.png)
+
+Defaults to `auto`.
+
 ### `filter_mode`
 
 The default filter to use when searching


### PR DESCRIPTION
I came across #288 by accident, wanted to try compact mode but couldn't figure how to. Turns out the option wasn't added to `config.toml`. Hope that makes sense to add it.

Also added to `config.md`.