### PR TITLE
Respect fish shell's builtin private mode

### DIFF
--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -1,7 +1,9 @@
 set -gx ATUIN_SESSION (atuin uuid)
 
 function _atuin_preexec --on-event fish_preexec
-    set -gx ATUIN_HISTORY_ID (atuin history start -- "$argv[1]")
+    if not test -n "$fish_private_mode"
+        set -gx ATUIN_HISTORY_ID (atuin history start -- "$argv[1]")
+    end
 end
 
 function _atuin_postexec --on-event fish_postexec


### PR DESCRIPTION
Fish shell has a private mode builtin, where commands are not written to the history file. This change only allows `atuin history start` when the fish shell is not in private mode.

See here for details on Private mode in fish: https://fishshell.com/docs/current/interactive.html?highlight=private#private-mode

Related #517 