### PR TITLE
docs: add more details about date parsing in the stats command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,6 @@ dependencies = [
  "atuin-server",
  "base64",
  "chrono",
- "chrono-english",
  "clap",
  "clap_complete",
  "cli-table",
@@ -96,6 +95,7 @@ dependencies = [
  "eyre",
  "fs-err",
  "indicatif",
+ "interim",
  "itertools",
  "log",
  "pretty_env_logger",
@@ -119,12 +119,12 @@ dependencies = [
  "atuin-common",
  "base64",
  "chrono",
- "chrono-english",
  "config",
  "directories",
  "eyre",
  "fs-err",
  "hex",
+ "interim",
  "itertools",
  "lazy_static",
  "log",
@@ -244,6 +244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,16 +314,6 @@ dependencies = [
  "time",
  "wasm-bindgen",
  "winapi",
-]
-
-[[package]]
-name = "chrono-english"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73d909da7eb4a7d88c679c3f5a1bc09d965754e0adb2e7627426cef96a00d6f"
-dependencies = [
- "chrono",
- "scanlex",
 ]
 
 [[package]]
@@ -945,6 +941,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "interim"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ffd2ac8397b9574daa4ffa7ede4427dd249cadaa900719d4b01154a5631d38b"
+dependencies = [
+ "chrono",
+ "logos",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1032,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "logos"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
+dependencies = [
+ "beef",
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn",
 ]
 
 [[package]]
@@ -1612,12 +1641,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scanlex"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db"
 
 [[package]]
 name = "schannel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ unicode-width = "0.1"
 itertools = "0.10.5"
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1.58"
-chrono-english = "0.1.4"
+interim = { version = "0.1.0", features = ["chrono"] }
 cli-table = { version = "0.4", default-features = false }
 base64 = "0.13.0"
 crossbeam-channel = "0.5.1"

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -31,7 +31,7 @@ eyre = "0.6"
 directories = "4"
 uuid = { version = "1.2", features = ["v4"] }
 whoami = "1.1.2"
-chrono-english = "0.1.4"
+interim = { version = "0.1.0", features = ["chrono"] }
 config = { version = "0.13", default-features = false, features = ["toml"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -55,6 +55,7 @@ impl FilterMode {
 }
 
 // FIXME: Can use upstream Dialect enum if https://github.com/stevedonovan/chrono-english/pull/16 is merged
+// FIXME: Above PR was merged, but dependency was changed to interim (fork of chrono-english) in the ... interim
 #[derive(Clone, Debug, Deserialize, Copy)]
 pub enum Dialect {
     #[serde(rename = "us")]
@@ -64,11 +65,11 @@ pub enum Dialect {
     Uk,
 }
 
-impl From<Dialect> for chrono_english::Dialect {
-    fn from(d: Dialect) -> chrono_english::Dialect {
+impl From<Dialect> for interim::Dialect {
+    fn from(d: Dialect) -> interim::Dialect {
         match d {
-            Dialect::Uk => chrono_english::Dialect::Uk,
-            Dialect::Us => chrono_english::Dialect::Us,
+            Dialect::Uk => interim::Dialect::Uk,
+            Dialect::Us => interim::Dialect::Us,
         }
     }
 }

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -1,10 +1,18 @@
 # `atuin stats`
 
 Atuin can also calculate stats based on your history - this is currently a
-little basic, but more features to come
+little basic, but more features to come.
+
+## 1-day stats
+
+You provide the starting point, and Atuin computes the stats for 24h from that point.
+Date parsing is provided by `chrono_english`, which supports different formats
+for full or relative dates. Certain formats rely on the dialect option in your
+[configuration](config.md#dialect) to differentiate day from month.
+Refer to [the module's documentation](https://docs.rs/chrono-english/0.1.4/chrono_english/#supported-formats) for more details on the supported date formats.
 
 ```
-$ atuin stats day last friday
+$ atuin stats last friday
 
 +---------------------+------------+
 | Statistic           | Value      |
@@ -16,12 +24,18 @@ $ atuin stats day last friday
 | Unique commands ran |        213 |
 +---------------------+------------+
 
-$ atuin stats day 01/01/21 # also accepts absolute dates
+# A few more examples:
+$ atuin stats 2018-04-01
+$ atuin stats April 1
+$ atuin stats 01/04/22
+$ atuin stats last thursday 3pm  # between last thursday 3:00pm and the following friday 3:00pm
 ```
 
-It can also calculate statistics for all of known history:
+## Full history stats
 
 ```
+$ atuin stats
+# or
 $ atuin stats all
 
 +---------------------+-------+

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -6,10 +6,10 @@ little basic, but more features to come.
 ## 1-day stats
 
 You provide the starting point, and Atuin computes the stats for 24h from that point.
-Date parsing is provided by `chrono_english`, which supports different formats
+Date parsing is provided by `interim`, which supports different formats
 for full or relative dates. Certain formats rely on the dialect option in your
 [configuration](config.md#dialect) to differentiate day from month.
-Refer to [the module's documentation](https://docs.rs/chrono-english/0.1.4/chrono_english/#supported-formats) for more details on the supported date formats.
+Refer to [the module's documentation](https://docs.rs/interim/0.1.0/interim/#supported-formats) for more details on the supported date formats.
 
 ```
 $ atuin stats last friday

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -154,11 +154,8 @@ async fn run_non_interactive(
             }
 
             if let Some(before) = &before {
-                let before = chrono_english::parse_date_string(
-                    before.as_str(),
-                    Utc::now(),
-                    chrono_english::Dialect::Uk,
-                );
+                let before =
+                    interim::parse_date_string(before.as_str(), Utc::now(), interim::Dialect::Uk);
 
                 if before.is_err() || h.timestamp.gt(&before.unwrap()) {
                     return false;
@@ -166,11 +163,8 @@ async fn run_non_interactive(
             }
 
             if let Some(after) = &after {
-                let after = chrono_english::parse_date_string(
-                    after.as_str(),
-                    Utc::now(),
-                    chrono_english::Dialect::Uk,
-                );
+                let after =
+                    interim::parse_date_string(after.as_str(), Utc::now(), interim::Dialect::Uk);
 
                 if after.is_err() || h.timestamp.lt(&after.unwrap()) {
                     return false;

--- a/src/command/client/stats.rs
+++ b/src/command/client/stats.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use chrono::{prelude::*, Duration};
-use chrono_english::parse_date_string;
 use clap::Parser;
 use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
 use eyre::{bail, Result};
+use interim::parse_date_string;
 
 use atuin_client::{
     database::{current_context, Database},


### PR DESCRIPTION
Hello 👋🏻 

I just spent a bit of time figuring out what the stats command can do and what the proper syntax is. I figured I'd spare some people some searching in the future by updating the documentation.

* Document the use of `chrono_english` and point to its documentation for date formatting.
* Document the fact that one can manipulate a 24h window, rather that just a specific day.
* Document the relationship with the `dialect` option in the configuration.
* Update the existing examples and add a few more.

Also, I think the stats command's help is a bit misleading for 2 reasons:
* The argument name `period` seems like a misnomer. Based on the code, the period is fixed, it's either 1-day or all of history. What the users really give is a starting point for that 1-day period.
* `period` is represented as a list. I get the idea, treat the command's arguments as a vector and reconstruct the string from there so that the users don't need to quote the period. But it makes it look as though we could potentially give multiple periods, which does not work.

I haven't changed anything in that regard in this PR. I have my idea about a better way to deal with this but I have no experience with rust at all which would make implementing it slow and complicated. Maybe those problems are worth an issue, I'll wait for your feedback on that.

Have a good day ! :)