### PR TITLE
Build ARM64 releases & update runners

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,8 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-18.04 , target: x86_64-unknown-linux-gnu    }
-          - { os: macos-10.15  , target: x86_64-apple-darwin         }
+          - { os: ubuntu-20.04 , target: x86_64-unknown-linux-gnu    }
+          - { os: ubuntu-20.04 , target: aarch64-unknown-linux-gnu    }
+          - { os: macos-12     , target: x86_64-apple-darwin         }
+          - { os: macos-12     , target: aarch64-apple-darwin         }
     steps:
     - name: Checkout source code
       uses: actions/checkout@v2


### PR DESCRIPTION
Not entirely sure how to test this workflow.

I updated the runners as the current ones being used are deprecated, and GitHub really seems to want people to move to newer ones.

I'm confused: why weren't ARM64 builds being made? The workflow literally has cases to handle it...

Fixes https://github.com/ellie/atuin/issues/369