### PR TITLE
fix #596: Avoid drawing a command section beyond the width  of the list

### DIFF
--- a/src/command/client/search/history_list.rs
+++ b/src/command/client/search/history_list.rs
@@ -159,7 +159,7 @@ impl DrawState<'_> {
 
         for section in h.command.split_ascii_whitespace() {
             self.x += 1;
-            if (self.x > self.list_area.width) {
+            if self.x > self.list_area.width {
                 // Avoid attempting to draw a command section beyond the width
                 // of the list
                 return;

--- a/src/command/client/search/history_list.rs
+++ b/src/command/client/search/history_list.rs
@@ -159,6 +159,11 @@ impl DrawState<'_> {
 
         for section in h.command.split_ascii_whitespace() {
             self.x += 1;
+            if (self.x > self.list_area.width) {
+                // Avoid attempting to draw a command section beyond the width
+                // of the list
+                return;
+            }
             self.draw(section, style);
         }
     }


### PR DESCRIPTION
For long commands that had sections (i.e. whitespace) that started beyond the width of the list, an underflow error would occur. This fixes this error by avoiding trying to print a command section beyond this boundary.

Fixes #596 