### PR TITLE
Fix logging in _atuin_preexec

### DIFF
--- a/src/shell/atuin.bash
+++ b/src/shell/atuin.bash
@@ -2,7 +2,7 @@ ATUIN_SESSION=$(atuin uuid)
 export ATUIN_SESSION
 
 _atuin_preexec() {
-    local id; id=$(atuin history start -- "$1")
+    local id; id=$(RUST_LOG=error atuin history start -- "$1")
     export ATUIN_HISTORY_ID="${id}"
 }
 

--- a/src/shell/atuin.bash
+++ b/src/shell/atuin.bash
@@ -1,4 +1,4 @@
-ATUIN_SESSION=$(atuin uuid)
+ATUIN_SESSION=$(RUST_LOG=error atuin uuid)
 export ATUIN_SESSION
 
 _atuin_preexec() {

--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -1,8 +1,8 @@
-set -gx ATUIN_SESSION (atuin uuid)
+set -gx ATUIN_SESSION (RUST_LOG=error atuin uuid)
 
 function _atuin_preexec --on-event fish_preexec
     if not test -n "$fish_private_mode"
-        set -gx ATUIN_HISTORY_ID (atuin history start -- "$argv[1]")
+        set -gx ATUIN_HISTORY_ID (RUST_LOG=error atuin history start -- "$argv[1]")
     end
 end
 

--- a/src/shell/atuin.zsh
+++ b/src/shell/atuin.zsh
@@ -9,11 +9,11 @@
 # Source this in your ~/.zshrc
 autoload -U add-zsh-hook
 
-export ATUIN_SESSION=$(atuin uuid)
+export ATUIN_SESSION=$(RUST_LOG=error atuin uuid)
 export ATUIN_HISTORY="atuin history list"
 
 _atuin_preexec(){
-	local id; id=$(atuin history start -- "$1")
+	local id; id=$(RUST_LOG=error atuin history start -- "$1")
 	export ATUIN_HISTORY_ID="$id"
 }
 


### PR DESCRIPTION
Override `RUST_LOG` in `_atuin_preexec` in order to avoid unexpected logs when `RUST_LOG` is set in bash.