### PR TITLE
Fix minor typo in config.md

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -140,7 +140,7 @@ Filter modes can still be toggled via ctrl-r
 
 
 ```
-search_mode = "fulltext"
+filter_mode = "host"
 ```
 
 ### `exit_mode`


### PR DESCRIPTION
This section of the config docs just used the wrong example text.

Closes #584 