### PR TITLE
Re-enable arm docker builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -54,7 +54,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64 #,linux/arm64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
The issues from the linked issue seemed to be closed, so I re-enabled arm docker builds to check.

[The build succeeded](https://github.com/patricksjackson/atuin/actions/runs/3485248571), and you can find the packages [here](https://github.com/patricksjackson/atuin/pkgs/container/atuin). I haven't had the chance to manually test it yet.

Closes #439