### PR TITLE
feat: add an inline view mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,8 +1764,7 @@ dependencies = [
 [[package]]
 name = "ratatui"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc0d032bccba900ee32151ec0265667535c230169f5a011154cdcd984e16829"
+source = "git+https://github.com/conradludgate/tui-rs-revival?branch=inline#6ed61959ecfc560e4e6a00a1410bb5fcbf0eda91"
 dependencies = [
  "bitflags",
  "cassowary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,6 @@ version = "0.3"
 default-features = false
 features = ["ansi", "fmt", "registry", "env-filter"]
 optional = true
+
+[patch.crates-io]
+ratatui = { git = "https://github.com/conradludgate/tui-rs-revival", branch = "inline" }

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -151,6 +151,7 @@ pub struct Settings {
     pub filter_mode: FilterMode,
     pub filter_mode_shell_up_key_binding: Option<FilterMode>,
     pub shell_up_key_binding: bool,
+    pub inline_height: u16,
     pub show_preview: bool,
     pub exit_mode: ExitMode,
     pub word_jump_mode: WordJumpMode,
@@ -336,6 +337,7 @@ impl Settings {
             .set_default("search_mode", "fuzzy")?
             .set_default("filter_mode", "global")?
             .set_default("shell_up_key_binding", false)?
+            .set_default("inline_height", 0)?
             .set_default("show_preview", false)?
             .set_default("exit_mode", "return-original")?
             .set_default("session_token", "")?

--- a/src/command/client/search/interactive.rs
+++ b/src/command/client/search/interactive.rs
@@ -466,29 +466,37 @@ impl State {
 
 struct Stdout {
     stdout: std::io::Stdout,
+    inline_mode: bool,
 }
 
 impl Stdout {
-    pub fn new() -> std::io::Result<Self> {
+    pub fn new(inline_mode: bool) -> std::io::Result<Self> {
         terminal::enable_raw_mode()?;
         let mut stdout = stdout();
+        if !inline_mode {
+            execute!(stdout, terminal::EnterAlternateScreen)?;
+        }
         execute!(
             stdout,
-            // terminal::EnterAlternateScreen,
             event::EnableMouseCapture,
-            event::EnableBracketedPaste
+            event::EnableBracketedPaste,
         )?;
-        Ok(Self { stdout })
+        Ok(Self {
+            stdout,
+            inline_mode,
+        })
     }
 }
 
 impl Drop for Stdout {
     fn drop(&mut self) {
+        if !self.inline_mode {
+            execute!(self.stdout, terminal::LeaveAlternateScreen).unwrap();
+        }
         execute!(
             self.stdout,
-            // terminal::LeaveAlternateScreen,
             event::DisableMouseCapture,
-            event::DisableBracketedPaste
+            event::DisableBracketedPaste,
         )
         .unwrap();
         terminal::disable_raw_mode().unwrap();
@@ -531,12 +539,16 @@ pub async fn history(
     settings: &Settings,
     db: &mut impl Database,
 ) -> Result<String> {
-    let stdout = Stdout::new()?;
+    let stdout = Stdout::new(settings.inline_height > 0)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::with_options(
         backend,
         TerminalOptions {
-            viewport: Viewport::Inline(24),
+            viewport: if settings.inline_height > 0 {
+                Viewport::Inline(settings.inline_height)
+            } else {
+                Viewport::Fullscreen
+            },
         },
     )?;
 
@@ -614,7 +626,9 @@ pub async fn history(
         }
     };
 
-    terminal.clear()?;
+    if settings.inline_height > 0 {
+        terminal.clear()?;
+    }
 
     if index < results.len() {
         // index is in bounds so we return that entry

--- a/src/command/client/search/interactive.rs
+++ b/src/command/client/search/interactive.rs
@@ -33,7 +33,7 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Span, Spans, Text},
     widgets::{Block, BorderType, Borders, Paragraph},
-    Frame, Terminal,
+    Frame, Terminal, TerminalOptions, Viewport,
 };
 
 const RETURN_ORIGINAL: usize = usize::MAX;
@@ -474,7 +474,7 @@ impl Stdout {
         let mut stdout = stdout();
         execute!(
             stdout,
-            terminal::EnterAlternateScreen,
+            // terminal::EnterAlternateScreen,
             event::EnableMouseCapture,
             event::EnableBracketedPaste
         )?;
@@ -486,7 +486,7 @@ impl Drop for Stdout {
     fn drop(&mut self) {
         execute!(
             self.stdout,
-            terminal::LeaveAlternateScreen,
+            // terminal::LeaveAlternateScreen,
             event::DisableMouseCapture,
             event::DisableBracketedPaste
         )
@@ -533,7 +533,12 @@ pub async fn history(
 ) -> Result<String> {
     let stdout = Stdout::new()?;
     let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = Terminal::with_options(
+        backend,
+        TerminalOptions {
+            viewport: Viewport::Inline(24),
+        },
+    )?;
 
     let mut input = Cursor::from(query.join(" "));
     // Put the cursor at the end of the query by default
@@ -608,6 +613,9 @@ pub async fn history(
             results = app.query_results(db).await?;
         }
     };
+
+    terminal.clear()?;
+
     if index < results.len() {
         // index is in bounds so we return that entry
         Ok(results.swap_remove(index).command.clone())


### PR DESCRIPTION
- Use crossterm and inline viewport
- Reposition cursor on exit and fix `The cursor position could not be read within a normal duration` errors due to blocking reads
