### PR TITLE
feat(history): Add new flag to allow custom output format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,10 +91,10 @@ dependencies = [
  "itertools",
  "log",
  "rpassword",
+ "runtime-format",
  "semver",
  "serde",
  "serde_json",
- "strfmt",
  "termion",
  "tokio",
  "tracing-subscriber",
@@ -1649,6 +1649,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "runtime-format"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b035308411b1af4683acc4fc928366443f08b893bb73e235c85de4c2be572495"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,12 +2041,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
 ]
-
-[[package]]
-name = "strfmt"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26cdabcdab6da7e8c2ac1160e917ec83e78bbe3e10325e17d532718c67a4828f"
 
 [[package]]
 name = "stringprep"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "strfmt",
  "termion",
  "tokio",
  "tracing-subscriber",
@@ -2033,6 +2034,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strfmt"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26cdabcdab6da7e8c2ac1160e917ec83e78bbe3e10325e17d532718c67a4828f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,18 +2111,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.34"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.34"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ fs-err = "2.7"
 whoami = "1.1.2"
 rpassword = "7.0"
 semver = "1.0.14"
-strfmt = "0.2.2"
+runtime-format = "0.1.2"
 
 [dependencies.tracing-subscriber]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ fs-err = "2.7"
 whoami = "1.1.2"
 rpassword = "7.0"
 semver = "1.0.14"
+strfmt = "0.2.2"
 
 [dependencies.tracing-subscriber]
 version = "0.3"

--- a/src/command/client/history.rs
+++ b/src/command/client/history.rs
@@ -1,14 +1,13 @@
 use std::{
     env,
+    fmt::{self, Display},
     io::{StdoutLock, Write},
     time::Duration,
 };
 
 use clap::Subcommand;
 use eyre::Result;
-
-use std::collections::HashMap;
-use strfmt::strfmt;
+use runtime_format::{FormatKey, FormatKeyError, ParsedFmt};
 
 use atuin_client::{
     database::{current_context, Database},
@@ -20,7 +19,7 @@ use atuin_client::{
 use atuin_client::sync;
 use log::debug;
 
-use super::search::format_duration;
+use super::search::format_duration_into;
 
 #[derive(Subcommand)]
 #[command(infer_subcommands = true)]
@@ -92,7 +91,7 @@ impl ListMode {
 }
 
 #[allow(clippy::cast_sign_loss)]
-pub fn print_list(h: &[History], list_mode: ListMode, format: Option<String>) {
+pub fn print_list(h: &[History], list_mode: ListMode, format: Option<&str>) {
     let w = std::io::stdout();
     let mut w = w.lock();
 
@@ -105,46 +104,54 @@ pub fn print_list(h: &[History], list_mode: ListMode, format: Option<String>) {
     w.flush().expect("failed to flush history");
 }
 
-#[allow(clippy::cast_sign_loss)]
-pub fn format_line(h: &History, format: &str) -> String {
-    let mut vars = HashMap::new();
-    vars.insert("command".to_string(), h.command.trim().to_string());
-    vars.insert("directory".to_string(), h.cwd.trim().to_string());
-    vars.insert(
-        "duration".to_string(),
-        format_duration(Duration::from_nanos(std::cmp::max(h.duration, 0) as u64)),
-    );
-    vars.insert(
-        "time".to_string(),
-        h.timestamp.format("%Y-%m-%d %H:%M:%S").to_string(),
-    );
-    let res = strfmt(format, &vars);
+/// type wrapper around `History` so we can implement traits
+struct FmtHistory<'a>(&'a History);
 
-    res.unwrap_or_else(|e| {
-        eprintln!("ERROR: History formatting failed with the following error: {e}");
-        println!("If your formatting string contains curly braces (eg: {{var}}) you need to escape them this way: {{{{var}}}}.");
-        std::process::exit(1)
-    })
-}
-
-pub fn print_human_list(w: &mut StdoutLock, h: &[History], format: Option<String>) {
-    let format = format
-        .unwrap_or_else(|| "{time} · {duration}\t{command}".to_string())
-        .replace("\\t", "\t");
-    for h in h.iter().rev() {
-        let line = format_line(h, &format);
-        writeln!(w, "{line}").expect("failed to write history");
+/// defines how to format the history
+impl FormatKey for FmtHistory<'_> {
+    #[allow(clippy::cast_sign_loss)]
+    fn fmt(&self, key: &str, f: &mut fmt::Formatter<'_>) -> Result<(), FormatKeyError> {
+        match key {
+            "command" => f.write_str(self.0.command.trim())?,
+            "directory" => f.write_str(self.0.cwd.trim())?,
+            "duration" => {
+                let dur = Duration::from_nanos(std::cmp::max(self.0.duration, 0) as u64);
+                format_duration_into(dur, f)?;
+            }
+            "time" => self.0.timestamp.format("%Y-%m-%d %H:%M:%S").fmt(f)?,
+            _ => return Err(FormatKeyError::UnknownKey),
+        }
+        Ok(())
     }
 }
 
-pub fn print_regular(w: &mut StdoutLock, h: &[History], format: Option<String>) {
-    let format = format
-        .unwrap_or_else(|| "{time}\t{command}\t{duration}".to_string())
-        .replace("\\t", "\t");
+fn print_list_with(w: &mut StdoutLock, h: &[History], format: &str) {
+    let fmt = match ParsedFmt::new(format) {
+        Ok(fmt) => fmt,
+        Err(err) => {
+            eprintln!("ERROR: History formatting failed with the following error: {err}");
+            println!("If your formatting string contains curly braces (eg: {{var}}) you need to escape them this way: {{{{var}}.");
+            std::process::exit(1)
+        }
+    };
+
     for h in h.iter().rev() {
-        let line = format_line(h, &format);
-        writeln!(w, "{line}").expect("failed to write history");
+        writeln!(w, "{}", fmt.with_args(&FmtHistory(h))).expect("failed to write history");
     }
+}
+
+pub fn print_human_list(w: &mut StdoutLock, h: &[History], format: Option<&str>) {
+    let format = format
+        .unwrap_or("{time} · {duration}\t{command}")
+        .replace("\\t", "\t");
+    print_list_with(w, h, &format);
+}
+
+pub fn print_regular(w: &mut StdoutLock, h: &[History], format: Option<&str>) {
+    let format = format
+        .unwrap_or("{time}\t{command}\t{duration}")
+        .replace("\\t", "\t");
+    print_list_with(w, h, &format);
 }
 
 pub fn print_cmd_only(w: &mut StdoutLock, h: &[History]) {
@@ -253,7 +260,7 @@ impl Cmd {
                 print_list(
                     &history,
                     ListMode::from_flags(*human, *cmd_only),
-                    format.clone(),
+                    format.as_deref(),
                 );
 
                 Ok(())
@@ -268,7 +275,7 @@ impl Cmd {
                 print_list(
                     &[last],
                     ListMode::from_flags(*human, *cmd_only),
-                    format.clone(),
+                    format.as_deref(),
                 );
 
                 Ok(())

--- a/src/command/client/history.rs
+++ b/src/command/client/history.rs
@@ -119,6 +119,13 @@ impl FormatKey for FmtHistory<'_> {
                 format_duration_into(dur, f)?;
             }
             "time" => self.0.timestamp.format("%Y-%m-%d %H:%M:%S").fmt(f)?,
+            "host" => f.write_str(
+                self.0
+                    .hostname
+                    .split_once(':')
+                    .map_or(&self.0.hostname, |(host, _)| host),
+            )?,
+            "user" => f.write_str(self.0.hostname.split_once(':').map_or("", |(_, user)| user))?,
             _ => return Err(FormatKeyError::UnknownKey),
         }
         Ok(())

--- a/src/command/client/history.rs
+++ b/src/command/client/history.rs
@@ -49,7 +49,7 @@ pub enum Cmd {
         #[arg(long)]
         cmd_only: bool,
 
-        /// Available variables: {command}, {directory}, {duration} and {time}.
+        /// Available variables: {command}, {directory}, {duration}, {user}, {host} and {time}.
         /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
         #[arg(long, short)]
         format: Option<String>,
@@ -64,7 +64,7 @@ pub enum Cmd {
         #[arg(long)]
         cmd_only: bool,
 
-        /// Available variables: {command}, {directory}, {duration} and {time}.
+        /// Available variables: {command}, {directory}, {duration}, {user}, {host} and {time}.
         /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
         #[arg(long, short)]
         format: Option<String>,

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -74,6 +74,11 @@ pub struct Cmd {
     /// Show only the text of the command
     #[arg(long)]
     cmd_only: bool,
+
+    /// Available variables: {command}, {directory}, {duration} and {time}.
+    /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
+    #[arg(long, short)]
+    format: Option<String>,
 }
 
 impl Cmd {
@@ -97,6 +102,7 @@ impl Cmd {
                 self.exit,
                 self.exclude_exit,
                 self.exclude_cwd,
+                self.format,
                 self.before,
                 self.after,
                 self.limit,
@@ -122,6 +128,7 @@ async fn run_non_interactive(
     exit: Option<i64>,
     exclude_exit: Option<i64>,
     exclude_cwd: Option<String>,
+    format: Option<String>,
     before: Option<String>,
     after: Option<String>,
     limit: Option<i64>,
@@ -202,6 +209,6 @@ async fn run_non_interactive(
         .map(std::borrow::ToOwned::to_owned)
         .collect();
 
-    super::history::print_list(&results, list_mode);
+    super::history::print_list(&results, list_mode, format.clone());
     Ok(results.len())
 }

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -16,7 +16,7 @@ mod duration;
 mod event;
 mod history_list;
 mod interactive;
-pub use duration::format_duration;
+pub use duration::{format_duration, format_duration_into};
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Parser)]
@@ -209,6 +209,6 @@ async fn run_non_interactive(
         .map(std::borrow::ToOwned::to_owned)
         .collect();
 
-    super::history::print_list(&results, list_mode, format.clone());
+    super::history::print_list(&results, list_mode, format.as_deref());
     Ok(results.len())
 }

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -75,7 +75,7 @@ pub struct Cmd {
     #[arg(long)]
     cmd_only: bool,
 
-    /// Available variables: {command}, {directory}, {duration} and {time}.
+    /// Available variables: {command}, {directory}, {duration}, {user}, {host} and {time}.
     /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
     #[arg(long, short)]
     format: Option<String>,


### PR DESCRIPTION
Fixes #619 

Hey, that's an easy one to implement but I'm not sure what's the best way to display it, here's a few examples:
```
❯ cargo run history list 2>/dev/null | tail -n1
2023-01-11 20:35:26     < /home/baptiste/github.com/BapRx/atuin >       cargo run history list 2>/dev/null | tail -n1   0s
❯ cargo run history list 2>/dev/null | tail -n1
2023-01-11 20:35:44     === /home/baptiste/github.com/BapRx/atuin ===   cargo run history list 2>/dev/null | tail -n1   0s
❯ cargo run history list 2>/dev/null | tail -n1
2023-01-11 20:36:00     (/home/baptiste/github.com/BapRx/atuin) cargo run history list 2>/dev/null | tail -n1   0s
❯ cargo run history list 2>/dev/null | tail -n1
2023-01-11 20:36:17     [/home/baptiste/github.com/BapRx/atuin] cargo run history list 2>/dev/null | tail -n1   0s
❯ cargo run history list 2>/dev/null | tail -n1
2023-01-11 20:37:10     /home/baptiste/github.com/BapRx/atuin$  cargo run history list 2>/dev/null | tail -n1   0s
```

If we want this to be optional I can add a flag like `--show-cwd`