### PR TITLE
Remove whitespace in template client config.tom

### DIFF
--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -10,7 +10,7 @@
 # session_path = "~/.key"
 
 ## date format used, either "us" or "uk"
-# dialect = "uk" 								
+# dialect = "uk"
 
 ## enable or disable automatic sync
 # auto_sync = true


### PR DESCRIPTION
Looks like this snuck in in the original config file here https://github.com/ellie/atuin/commit/9f16f76bd8d15824e27e971245ea93271fe76b29#diff-28043ff911f28a5cb5742f7638363546311225a63eabc365af5356c70d4deb77R13