### PR TITLE
fish: Fix `atuin init` for the fish shell

### DIFF
--- a/src/shell/atuin.fish
+++ b/src/shell/atuin.fish
@@ -15,7 +15,7 @@ function _atuin_postexec --on-event fish_postexec
 end
 
 function _atuin_search
-    set h (RUST_LOG=error atuin search $* -i -- (commandline -b) 3>&1 1>&2 2>&3)
+    set h (RUST_LOG=error atuin search $argv -i -- (commandline -b) 3>&1 1>&2 2>&3)
     commandline -f repaint
     if test -n "$h"
         commandline -r $h


### PR DESCRIPTION
When I try to do `atuin init` I get a error from fish, suggesting to replace `$*` with `$argv`.

This patch does that and makes fish accept with `atuin init fish --disable-up-arrow`. I did not do much testing after that though :-)