### PR TITLE
Remove shortcut numbers

### DIFF
--- a/src/command/client/search/history_list.rs
+++ b/src/command/client/search/history_list.rs
@@ -112,14 +112,11 @@ pub const PREFIX_LENGTH: u16 = " > 123ms 59s ago".len() as u16;
 
 impl DrawState<'_> {
     fn index(&mut self) {
-        // these encode the slices of `" > "`, `" {n} "`, or `"   "` in a compact form.
-        // Yes, this is a hack, but it makes me feel happy
-        static SLICES: &str = " > 1 2 3 4 5 6 7 8 9   ";
-
-        let i = self.y as usize + self.state.offset;
-        let i = i.checked_sub(self.state.selected);
-        let i = i.unwrap_or(10).min(10) * 2;
-        self.draw(&SLICES[i..i + 3], Style::default());
+        if self.y as usize + self.state.offset == self.state.selected {
+            self.draw(" >> ", Style::default());
+        } else {
+            self.draw("    ", Style::default());
+        }
     }
 
     fn duration(&mut self, h: &History) {

--- a/src/command/client/search/interactive.rs
+++ b/src/command/client/search/interactive.rs
@@ -94,7 +94,6 @@ impl State {
         len: usize,
     ) -> Option<usize> {
         let ctrl = input.modifiers.contains(KeyModifiers::CONTROL);
-        let alt = input.modifiers.contains(KeyModifiers::ALT);
         match input.code {
             KeyCode::Char('c' | 'd' | 'g') if ctrl => return Some(RETURN_ORIGINAL),
             KeyCode::Esc => {
@@ -105,10 +104,6 @@ impl State {
             }
             KeyCode::Enter => {
                 return Some(self.results_state.selected());
-            }
-            KeyCode::Char(c @ '1'..='9') if alt => {
-                let c = c.to_digit(10)? as usize;
-                return Some(self.results_state.selected() + c);
             }
             KeyCode::Left => {
                 self.input.left();


### PR DESCRIPTION
I never used them and I think they're just visual clutter. They also had keybinding issues on mac.

I'll leave this open for a while, in case they are a key part of anyone's workflow?