### PR TITLE
Add `history_filter` setting to exclude commands from history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_regex",
  "sha2",
  "shellexpand",
  "sodiumoxide",
@@ -1868,6 +1869,16 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
  "serde",
 ]
 

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -47,6 +47,7 @@ sqlx = { version = "0.6", features = [
 ] }
 minspan = "0.1.1"
 regex = "1.5.4"
+serde_regex = "1.1.0"
 fs-err = "2.9"
 sql-builder = "3"
 lazy_static = "1"

--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -37,3 +37,13 @@
 ## what to do when the escape key is pressed when searching
 ## possible values: return-original, return-query
 # exit_mode = "return-original"
+
+## prevent commands matching any of these regexes from being written to history.
+## Note that these regular expressions are unanchored, i.e. if they don't start
+## with ^ or end with $, they'll match anywhere in the command.
+## For details on the supported regular expression syntax, see
+## https://docs.rs/regex/latest/regex/#syntax
+# history_filter = [
+#   "^secret-cmd",
+#   "^innocuous-cmd .*--secret=.+"
+# ]

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -9,6 +9,7 @@ use config::{Config, Environment, File as ConfigFile, FileFormat};
 use eyre::{eyre, Context, Result};
 use fs_err::{create_dir_all, File};
 use parse_duration::parse;
+use regex::RegexSet;
 use semver::Version;
 use serde::Deserialize;
 
@@ -112,6 +113,9 @@ pub struct Settings {
     pub filter_mode_shell_up_key_binding: FilterMode,
     pub shell_up_key_binding: bool,
     pub exit_mode: ExitMode,
+    #[serde(with = "serde_regex", default = "RegexSet::empty")]
+    pub history_filter: RegexSet,
+
     // This is automatically loaded when settings is created. Do not set in
     // config! Keep secrets and settings apart.
     pub session_token: String,

--- a/src/command/client/history.rs
+++ b/src/command/client/history.rs
@@ -175,7 +175,7 @@ impl Cmd {
             Self::Start { command: words } => {
                 let command = words.join(" ");
 
-                if command.starts_with(' ') {
+                if command.starts_with(' ') || settings.history_filter.is_match(&command) {
                     return Ok(());
                 }
 


### PR DESCRIPTION
Adds a new `history_filter` setting through which users can specify a list of regular expressions that match commands that should not be recorded in the history.

Example configuration:
```toml
## prevent commands matching any of these regexes from being written to history.
## Note that these regular expressions are unanchored, i.e. if they don't start
## with ^ or end with $, they'll match anywhere in the command.
## For details on the supported regular expression syntax, see
## https://docs.rs/regex/latest/regex/#syntax
history_filter = [
   "^secret-cmd",
   "^innocuous-cmd .*--secret=.+"
]
```

Fixes #515