### PR TITLE
Revert "Re-enable arm docker builds (#616)"

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -54,7 +54,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64 #,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
Docker builds are failing on ARM, let's see if they work on AMD.

Might be worth waiting until we have less C that needs building

This reverts commit f3894ef9c0c9d2d9effa963b116d0075d4e7a9e5.