### PR TITLE
[docs] fix some links between config and commands

### DIFF
--- a/docs/docs/commands/stats.md
+++ b/docs/docs/commands/stats.md
@@ -8,7 +8,7 @@ little basic, but more features to come.
 You provide the starting point, and Atuin computes the stats for 24h from that point.
 Date parsing is provided by `interim`, which supports different formats
 for full or relative dates. Certain formats rely on the dialect option in your
-[configuration](config.md#dialect) to differentiate day from month.
+[configuration](/docs/config/config.md#dialect) to differentiate day from month.
 Refer to [the module's documentation](https://docs.rs/interim/0.1.0/interim/#supported-formats) for more details on the supported date formats.
 
 ```

--- a/docs/docs/commands/sync.md
+++ b/docs/docs/commands/sync.md
@@ -6,13 +6,13 @@ server operator can _never_ see your data!
 
 Anyone can host a server (try `atuin server start`, more docs to follow), but I
 host one at https://api.atuin.sh. This is the default server address, which can
-be changed in the [config](config.md). Again, I _cannot_ see your data, and
+be changed in the [config](/docs/config/config.md#sync_address). Again, I _cannot_ see your data, and
 do not want to.
 
 ## Sync frequency
 
 Syncing will happen automatically, unless configured otherwise. The sync
-frequency is configurable in [config](config.md)
+frequency is configurable in [config](/docs/config/config.md#sync_frequency)
 
 ## Sync
 

--- a/docs/docs/config/config.md
+++ b/docs/docs/config/config.md
@@ -23,7 +23,7 @@ See [config.toml](../atuin-client/config.toml) for an example
 
 ### `dialect`
 
-This configures how the [stats](stats.md) command parses dates. It has two
+This configures how the [stats](/docs/commands/stats.md) command parses dates. It has two
 possible values
 
 ```
@@ -193,9 +193,9 @@ or `py`.
 
 ### history_filter
 
-The history filter allows you to exclude commands from history tracking - maybe you want to keep ALL of your `curl` commands totally out of your shell history, or maybe just some matching a pattern. 
+The history filter allows you to exclude commands from history tracking - maybe you want to keep ALL of your `curl` commands totally out of your shell history, or maybe just some matching a pattern.
 
-This supports regular expressions, so you can hide pretty much whatever you want! 
+This supports regular expressions, so you can hide pretty much whatever you want!
 
 ```
 ## Note that these regular expressions are unanchored, i.e. if they don't start


### PR DESCRIPTION
Add anchors while at it.

I verified by running the docs with `yarn start` locally