### PR TITLE
Disable 2 tests that shouldn't run in release mode

### DIFF
--- a/src/tui/buffer.rs
+++ b/src/tui/buffer.rs
@@ -480,6 +480,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "outside the buffer")]
     fn pos_of_panics_on_out_of_bounds() {
         let rect = Rect::new(0, 0, 10, 10);
@@ -490,6 +491,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "outside the buffer")]
     fn index_of_panics_on_out_of_bounds() {
         let rect = Rect::new(0, 0, 10, 10);


### PR DESCRIPTION
These tests expect `debug_assert!` to panic, so should only run in debug mode:
- `pos_of_panics_on_out_of_bounds`
- `index_of_panics_on_out_of_bounds`

I came across this problem when [my COPR build](https://copr.fedorainfracloud.org/coprs/cyqsimon/el-rust-pkgs/builds/) failed, because I ran `cargo test --release` in the build script.