### PR TITLE
nix: add flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -33,6 +49,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,10 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
   };
   outputs = {
     self,


### PR DESCRIPTION
Support nix (non-flakes), continuation of #477.
- tested changes on top of v12.0.0 (cargo test fails for nix on v13.0.0)

# using nix-shell (legacy)
```
[shell:~/atuin]$ nix-shell
[nix-shell:~/atuin]$ cargo build
[...]
   Compiling atuin-client v12.0.0 (/root/atuin/atuin-client)
   Compiling atuin-server v12.0.0 (/root/atuin/atuin-server)
   Compiling atuin v12.0.0 (/root/atuin)
    Finished dev [unoptimized + debuginfo] target(s) in 1m 34s
[nix-shell:~/atuin]$
```
# using nix-build (legacy)
```
[shell:~/atuin]$ nix-build -A packages.aarch64-linux.atuin
[...]
/nix/store/ri763ifjs3vrba8s3w64lan24j34mm54-atuin
```

