### PR TITLE
fix(client): always read session_path from settings

### DIFF
--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -184,9 +184,7 @@ impl Settings {
     }
 
     pub fn should_sync(&self) -> Result<bool> {
-        let session_path = atuin_common::utils::data_dir().join("session");
-
-        if !self.auto_sync || !session_path.exists() {
+        if !self.auto_sync || !PathBuf::from(self.session_path.as_str()).exists() {
             return Ok(false);
         }
 

--- a/src/command/client/sync.rs
+++ b/src/command/client/sync.rs
@@ -39,7 +39,7 @@ impl Cmd {
         match self {
             Self::Sync { force } => run(&settings, force, db).await,
             Self::Login(l) => l.run(&settings).await,
-            Self::Logout => logout::run(),
+            Self::Logout => logout::run(&settings),
             Self::Register(r) => r.run(&settings).await,
             Self::Key { base64 } => {
                 use atuin_client::encryption::{encode_key, load_key};

--- a/src/command/client/sync/login.rs
+++ b/src/command/client/sync/login.rs
@@ -33,9 +33,9 @@ fn get_input() -> Result<String> {
 
 impl Cmd {
     pub async fn run(&self, settings: &Settings) -> Result<()> {
-        let session_path = atuin_common::utils::data_dir().join("session");
+        let session_path = settings.session_path.as_str();
 
-        if session_path.exists() {
+        if PathBuf::from(session_path).exists() {
             println!(
                 "You are already logged in! Please run 'atuin logout' if you wish to login again"
             );

--- a/src/command/client/sync/logout.rs
+++ b/src/command/client/sync/logout.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use eyre::{Context, Result};
 use fs_err::remove_file;
 
@@ -7,7 +9,7 @@ pub fn run(settings: &Settings) -> Result<()> {
     let session_path = settings.session_path.as_str();
 
     if PathBuf::from(session_path).exists() {
-        remove_file(session_path.as_path()).context("Failed to remove session file")?;
+        remove_file(session_path).context("Failed to remove session file")?;
         println!("You have logged out!");
     } else {
         println!("You are not logged in");

--- a/src/command/client/sync/logout.rs
+++ b/src/command/client/sync/logout.rs
@@ -1,10 +1,12 @@
 use eyre::{Context, Result};
 use fs_err::remove_file;
 
-pub fn run() -> Result<()> {
-    let session_path = atuin_common::utils::data_dir().join("session");
+use atuin_client::{settings::Settings};
 
-    if session_path.exists() {
+pub fn run(settings: &Settings) -> Result<()> {
+    let session_path = settings.session_path.as_str();
+
+    if PathBuf::from(session_path).exists() {
         remove_file(session_path.as_path()).context("Failed to remove session file")?;
         println!("You have logged out!");
     } else {

--- a/src/command/client/sync/logout.rs
+++ b/src/command/client/sync/logout.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use eyre::{Context, Result};
 use fs_err::remove_file;
 
-use atuin_client::{settings::Settings};
+use atuin_client::settings::Settings;
 
 pub fn run(settings: &Settings) -> Result<()> {
     let session_path = settings.session_path.as_str();


### PR DESCRIPTION
When setting the `session_path` config to a non-default value, `auto_sync` and `sync_frequency` were having no effect for me.

After digging into the code, I noticed that `settings.should_sync()` and the `login` and `lougout` commands were reading `session_path` as `atuin_common::utils::data_dir().join("session")` which was not the same as the value I set in my `config.toml`.

This PR should standardize all the places that read `session_path` to `settings.session_path`, which was already how it was done in a few places including the `register` command.

**Note**: I've basically never written Rust before and while making these changes I'm attempting to get my local env setup for Rust dev, but things are still installing as I type this. So there's a good chance this doesn't even compile but I'll come to fix it up or ask questions once I get it running locally.