### PR TITLE
Improve import, again

### DIFF
--- a/src/command/client.rs
+++ b/src/command/client.rs
@@ -22,7 +22,6 @@ pub enum Cmd {
     History(history::Cmd),
 
     /// Import shell history from file
-    #[command(subcommand)]
     Import(import::Cmd),
 
     /// Calculate statistics for your history

--- a/src/command/client/import.rs
+++ b/src/command/client/import.rs
@@ -28,7 +28,7 @@ pub enum Shell {
 
     /// Import history from the zsh history file
     Zsh,
-    /// Import history from the zsh history file
+    /// Import history from the zsh history SQL database file
     ZshHistDb,
     /// Import history from the bash history file
     Bash,
@@ -43,9 +43,17 @@ const BATCH_SIZE: usize = 100;
 #[derive(Clone, Debug, Parser)]
 pub struct Cmd {
     #[arg(long = "from-file", value_name = "PATH", value_hint = ValueHint::FilePath)]
+    /// Specify a custom file to import from, instead of the default locations
+    /// of each shell.
+    ///
+    /// When using this option, it's mandatory to explicitly specify the shell type.
+    ///
+    /// Alternatively, you can use the environment variable `$HISTFILE` to specify
+    /// the custom file too.
     custom_source: Option<PathBuf>,
 
     #[arg(index = 1)]
+    /// Which shell's history to import from.
     shell: Shell,
 }
 

--- a/src/command/client/import.rs
+++ b/src/command/client/import.rs
@@ -52,11 +52,8 @@ impl Cmd {
 
                 let shell = env::var("SHELL").unwrap_or_else(|_| String::from("NO_SHELL"));
                 if shell.ends_with("/zsh") {
-                    if ZshHistDb::histpath().is_ok() {
-                        println!(
-                            "Detected Zsh-HistDb, using :{}",
-                            ZshHistDb::histpath().unwrap().to_str().unwrap()
-                        );
+                    if let Ok(path) = ZshHistDb::histpath() {
+                        println!("Detected Zsh-HistDb, using {path:?}",);
                         import::<ZshHistDb, DB>(db).await
                     } else {
                         println!("Detected ZSH");


### PR DESCRIPTION
## Motive

I am recently distro-hopping and wanted to import my `.bash_history` from another file root that's mounted on `/run/media/OldRoot`. It wasn't initially obvious whether this is supported, so I read the code and found the `$HISTFILE` environment variable. It worked well enough for Bash, but it seems like the implementation is inconsistent across different kind of shells.
- Fish's import code seems to ignore `$HISTFILE` entirely
- Zsh's import code uses `$HISTFILE` for importing plain text history, but uses the largely-undocumented `$HISTDB_FILE` for importing history in SQL db file
- The way dependency injection is done is not very "Rusty", and can be easily overlooked by later implementers

So I thought I'd improve this situation.

## Change summary
1. Improve the `Importer` trait. Now structs just need to implement `Importer::default_source_path`, and `Importer::final_source_path` is automatically provided.
2. `$HISTFILE` is now universally respected for all shell types.
3. `$HISTDB_FILE` is no longer used. Instead the import code will try to infer whether `$HISTFILE` points to a SQL db or a plain text file.
4. Added a `--from-file` flag to the `import` subcommand, which does the same thing as `$HISTFILE` but is more discoverable.
5. Other minor code style changes that improves cleaniness and readability IMO.

## Todo
- [x] implementation
- [ ] documentation