### PR TITLE
Switch to using uuidv7

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "uuid_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,9 +159,7 @@ name = "atuin-common"
 version = "13.0.1"
 dependencies = [
  "chrono",
- "hex",
  "serde",
- "sha2",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,7 +159,9 @@ name = "atuin-common"
 version = "13.0.1"
 dependencies = [
  "chrono",
+ "hex",
  "serde",
+ "sha2",
  "uuid",
 ]
 
@@ -2540,10 +2551,11 @@ checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "uuid"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
+ "atomic",
  "getrandom",
 ]
 

--- a/atuin-client/src/event.rs
+++ b/atuin-client/src/event.rs
@@ -2,7 +2,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
 use crate::history::History;
-use atuin_common::utils::uuid_v4;
+use atuin_common::utils::uuid_v7;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum EventType {
@@ -23,7 +23,7 @@ pub struct Event {
 impl Event {
     pub fn new_create(history: &History) -> Event {
         Event {
-            id: uuid_v4(),
+            id: uuid_v7(),
             timestamp: history.timestamp,
             hostname: history.hostname.clone(),
             event_type: EventType::Create,
@@ -36,7 +36,7 @@ impl Event {
         let hostname = format!("{}:{}", whoami::hostname(), whoami::username());
 
         Event {
-            id: uuid_v4(),
+            id: uuid_v7(),
             timestamp: chrono::Utc::now(),
             hostname,
             event_type: EventType::Create,

--- a/atuin-client/src/history.rs
+++ b/atuin-client/src/history.rs
@@ -3,7 +3,7 @@ use std::env;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
-use atuin_common::utils::uuid_v4;
+use atuin_common::utils::uuid_v7;
 
 // Any new fields MUST be Optional<>!
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, sqlx::FromRow)]
@@ -30,12 +30,12 @@ impl History {
     ) -> Self {
         let session = session
             .or_else(|| env::var("ATUIN_SESSION").ok())
-            .unwrap_or_else(uuid_v4);
+            .unwrap_or_else(uuid_v7);
         let hostname =
             hostname.unwrap_or_else(|| format!("{}:{}", whoami::hostname(), whoami::username()));
 
         Self {
-            id: uuid_v4(),
+            id: uuid_v7(),
             timestamp,
             command,
             cwd,

--- a/atuin-client/src/import/resh.rs
+++ b/atuin-client/src/import/resh.rs
@@ -6,7 +6,7 @@ use directories::UserDirs;
 use eyre::{eyre, Result};
 use serde::Deserialize;
 
-use atuin_common::utils::uuid_v4;
+use atuin_common::utils::uuid_v7;
 
 use super::{get_histpath, unix_byte_lines, Importer, Loader};
 use crate::history::History;
@@ -123,13 +123,13 @@ impl Importer for Resh {
             };
 
             h.push(History {
-                id: uuid_v4(),
+                id: uuid_v7(),
                 timestamp,
                 duration,
                 exit: entry.exit_code,
                 command: entry.cmd_line,
                 cwd: entry.pwd,
-                session: uuid_v4(),
+                session: uuid_v7(),
                 hostname: entry.host,
             })
             .await?;

--- a/atuin-common/Cargo.toml
+++ b/atuin-common/Cargo.toml
@@ -14,5 +14,3 @@ repository = "https://github.com/ellie/atuin"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0.145", features = ["derive"] }
 uuid = { version = "1.3", features = ["v7"] }
-sha2 = { version = "0.10" }
-hex = { version = "0.4" }

--- a/atuin-common/Cargo.toml
+++ b/atuin-common/Cargo.toml
@@ -13,4 +13,6 @@ repository = "https://github.com/ellie/atuin"
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0.145", features = ["derive"] }
-uuid = { version = "1.2", features = ["v4"] }
+uuid = { version = "1.3", features = ["v7"] }
+sha2 = { version = "0.10" }
+hex = { version = "0.4" }

--- a/atuin-common/src/utils.rs
+++ b/atuin-common/src/utils.rs
@@ -3,8 +3,19 @@ use std::path::PathBuf;
 use chrono::NaiveDate;
 use uuid::Uuid;
 
-pub fn uuid_v4() -> String {
-    Uuid::new_v4().as_simple().to_string()
+pub fn uuid_v7() -> String {
+    Uuid::now_v7().as_simple().to_string()
+}
+
+pub fn hash_str(string: &str) -> String {
+    hash_bytes(string.as_bytes())
+}
+
+pub fn hash_bytes(buf: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(buf);
+    hex::encode(hasher.finalize())
 }
 
 // TODO: more reliable, more tested

--- a/atuin-common/src/utils.rs
+++ b/atuin-common/src/utils.rs
@@ -7,17 +7,6 @@ pub fn uuid_v7() -> String {
     Uuid::now_v7().as_simple().to_string()
 }
 
-pub fn hash_str(string: &str) -> String {
-    hash_bytes(string.as_bytes())
-}
-
-pub fn hash_bytes(buf: &[u8]) -> String {
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(buf);
-    hex::encode(hasher.finalize())
-}
-
 // TODO: more reliable, more tested
 // I don't want to use ProjectDirs, it puts config in awkward places on
 // mac. Data too. Seems to be more intended for GUI apps.

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -60,7 +60,7 @@ impl AtuinCmd {
                 Ok(())
             }
             Self::Uuid => {
-                println!("{}", atuin_common::utils::uuid_v4());
+                println!("{}", atuin_common::utils::uuid_v7());
                 Ok(())
             }
             Self::GenCompletions { shell, out_dir } => {


### PR DESCRIPTION
Why?

uuidv4 is totally random. uuidv7 has a time-based prefix, ie, they
_sort_.

This is important when we start to think about database indices. btree
indices have shit performance when the elements are totally random, but
good insertion + perf when they are sorted. Plus it's just kinda useful
to be able to sort them

I don't think it's worth re-ID-ing past data, but at least from hereon
out future data will be nice

TODO: Update the database schema to use the UUID type, and not just a
string.

Also we need the unstable flags here, as uuidv7 is technically not a finished spec.