### PR TITLE
Fixes a bug on windows

### DIFF
--- a/src/command/client/search/interactive.rs
+++ b/src/command/client/search/interactive.rs
@@ -94,6 +94,10 @@ impl State {
         input: &KeyEvent,
         len: usize,
     ) -> Option<usize> {
+        if input.kind == event::KeyEventKind::Release {
+            return None;
+        }
+
         let ctrl = input.modifiers.contains(KeyModifiers::CONTROL);
         let alt = input.modifiers.contains(KeyModifiers::ALT);
         match input.code {
@@ -474,13 +478,6 @@ pub async fn history(
 
         let initial_input = app.input.as_str().to_owned();
         let initial_filter_mode = app.filter_mode;
-
-        {
-            // We do this because windows does double inputs and captures the `Enter` when running a
-            // command
-            #[cfg(target_os = "windows")]
-            let _ = event::read();
-        };
 
         let event_ready = tokio::task::spawn_blocking(|| event::poll(Duration::from_millis(250)));
 

--- a/src/command/client/search/interactive.rs
+++ b/src/command/client/search/interactive.rs
@@ -88,7 +88,7 @@ impl State {
         None
     }
 
-    #[allow(clippy::to_many_lines)]
+    #[allow(clippy::too_many_lines)]
     fn handle_key_input(
         &mut self,
         settings: &Settings,

--- a/src/command/client/search/interactive.rs
+++ b/src/command/client/search/interactive.rs
@@ -88,6 +88,7 @@ impl State {
         None
     }
 
+    #[allow(clippy::to_many_lines)]
     fn handle_key_input(
         &mut self,
         settings: &Settings,


### PR DESCRIPTION
Fixes the bug that I tried to fix in https://github.com/ellie/atuin/pull/754.

The bug was that it was not distinguishing between `Release` and `Press`. The "fix" *was* to throw away one  input. But this is pragmatic because:
- Git bash does not send both `Release` and `Press`.
- Cgywin compiles it for linux, runs it as linux, thus the fix wont work.

This fixes it by throwing away any `Release` ones.