### PR TITLE
Prefer PWD environment variable over cwd if available to better support symbolic links

### DIFF
--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -1,6 +1,7 @@
 use std::{env, path::Path, str::FromStr};
 
 use async_trait::async_trait;
+use atuin_common::utils;
 use chrono::{prelude::*, Utc};
 use fs_err as fs;
 use itertools::Itertools;
@@ -31,10 +32,7 @@ pub fn current_context() -> Context {
         std::process::exit(1);
     };
     let hostname = format!("{}:{}", whoami::hostname(), whoami::username());
-    let cwd = match env::current_dir() {
-        Ok(dir) => dir.display().to_string(),
-        Err(_) => String::from(""),
-    };
+    let cwd = utils::get_current_dir();
 
     Context {
         session,

--- a/atuin-common/src/utils.rs
+++ b/atuin-common/src/utils.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::path::PathBuf;
 
 use chrono::NaiveDate;
@@ -34,6 +35,17 @@ pub fn data_dir() -> PathBuf {
         .map_or_else(|_| home_dir().join(".local").join("share"), PathBuf::from);
 
     data_dir.join("atuin")
+}
+
+pub fn get_current_dir() -> String {
+    // Prefer PWD environment variable over cwd if available to better support symbolic links
+    match env::var("PWD") {
+        Ok(v) => v,
+        Err(_) => match env::current_dir() {
+            Ok(dir) => dir.display().to_string(),
+            Err(_) => String::from(""),
+        },
+    }
 }
 
 pub fn get_days_from_month(year: i32, month: u32) -> i64 {

--- a/src/command/client/history.rs
+++ b/src/command/client/history.rs
@@ -5,6 +5,7 @@ use std::{
     time::Duration,
 };
 
+use atuin_common::utils;
 use clap::Subcommand;
 use eyre::Result;
 use runtime_format::{FormatKey, FormatKeyError, ParsedFmt};
@@ -181,8 +182,7 @@ impl Cmd {
 
                 // It's better for atuin to silently fail here and attempt to
                 // store whatever is ran, than to throw an error to the terminal
-                let cwd = env::current_dir()
-                    .map_or_else(|_| String::new(), |dir| dir.display().to_string());
+                let cwd = utils::get_current_dir();
 
                 let h = History::new(chrono::Utc::now(), command, cwd, -1, -1, None, None);
 
@@ -240,7 +240,7 @@ impl Cmd {
                     None
                 };
                 let cwd = if *cwd {
-                    Some(env::current_dir()?.display().to_string())
+                    Some(utils::get_current_dir())
                 } else {
                     None
                 };

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -1,3 +1,4 @@
+use atuin_common::utils;
 use chrono::Utc;
 use clap::Parser;
 use eyre::Result;
@@ -137,11 +138,7 @@ async fn run_non_interactive(
     db: &mut impl Database,
 ) -> Result<usize> {
     let dir = if cwd.as_deref() == Some(".") {
-        let current = std::env::current_dir()?;
-        let current = current.as_os_str();
-        let current = current.to_str().unwrap();
-
-        Some(current.to_owned())
+        Some(utils::get_current_dir())
     } else {
         cwd
     };


### PR DESCRIPTION
This PR uses the PWD environment variable if it is available instead of calling `env::current_dir()`.

Motivation: I was short on storage space in my main `/home/user` filesystem, so I moved all my `/home/user/workspaces` to another disk at `/home/newdisk/user/workspaces`, then created a symbolic link from `/home/user/workspaces` to `/home/newdisk/user/workspaces`.
To my dismay, when I searched my command history with the `directory` filter mode, nothing showed up.

For reference:
* https://github.com/rust-lang/rust/issues/93598#issuecomment-1028624102
* https://stackoverflow.com/a/71625035/316805

