### PR TITLE
Fix skim search

### DIFF
--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -452,6 +452,7 @@ impl Database for Sqlite {
                 "max(duration) as duration",
                 "exit",
                 "command",
+                "deleted_at",
                 "group_concat(cwd, ':') as cwd",
                 "group_concat(session) as session",
                 "group_concat(hostname, ',') as hostname",


### PR DESCRIPTION
We use the generic row -> history, which expects deleted_at to exist

Fix it!