### PR TITLE
Delete all instances of a command

### DIFF
--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -460,6 +460,7 @@ impl Database for Sqlite {
             ])
             .group_by("command")
             .group_by("exit")
+            .and_where("deleted_at is null")
             .order_desc("timestamp");
 
         let query = query.sql().expect("bug in list query. please report");

--- a/atuin-client/src/sync.rs
+++ b/atuin-client/src/sync.rs
@@ -111,6 +111,9 @@ async fn sync_upload(
 ) -> Result<()> {
     debug!("starting sync upload");
 
+    let remote_status = client.status().await?;
+    let remote_deleted: HashSet<String> = HashSet::from_iter(remote_status.deleted.clone());
+
     let initial_remote_count = client.count().await?;
     let mut remote_count = initial_remote_count;
 
@@ -157,6 +160,10 @@ async fn sync_upload(
     let deleted = db.deleted().await?;
 
     for i in deleted {
+        if remote_deleted.contains(&i.id) {
+            continue;
+        }
+
         info!("deleting {} on remote", i.id);
         client.delete_history(i).await?;
     }


### PR DESCRIPTION
Our search command will de-dupe results by default. But... This isn't great for deleting! You don't want to run it over-and-over-and-over until all commands are deleted.

Loop the query, and keep on deleting what it returns until they are all gone.