### PR TITLE
feat: respect exit_mode setting when exiting with arrow down keypress

### DIFF
--- a/src/command/client/search/interactive.rs
+++ b/src/command/client/search/interactive.rs
@@ -231,7 +231,12 @@ impl State {
                 self.search.switched_search_mode = true;
                 self.search.search_mode = self.search.search_mode.next(settings);
             }
-            KeyCode::Down if self.results_state.selected() == 0 => return Some(RETURN_ORIGINAL),
+            KeyCode::Down if self.results_state.selected() == 0 => {
+                return Some(match settings.exit_mode {
+                    ExitMode::ReturnOriginal => RETURN_ORIGINAL,
+                    ExitMode::ReturnQuery => RETURN_QUERY,
+                })
+            }
             KeyCode::Down => {
                 let i = self.results_state.selected().saturating_sub(1);
                 self.results_state.select(i);


### PR DESCRIPTION
I set `exit_mode` to `return-query`, and since the introduction of https://github.com/ellie/atuin/pull/659, I'm often caught loosing everything I typed.

An additional improvement may be to add a visual indicator that we are on the last history item, thus giving an hint that pressing the arrow down key will exit.