### PR TITLE
Account for user not yet having count cache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Firstly, thank you so much for considering contributing to Atuin!

--- a/atuin-server/src/handlers/status.rs
+++ b/atuin-server/src/handlers/status.rs
@@ -14,16 +14,23 @@ pub async fn status<DB: Database>(
 ) -> Result<Json<StatusResponse>, ErrorResponseStatus<'static>> {
     let db = &state.0.database;
 
-    let history_count = db.count_history_cached(&user).await;
-    let deleted = db.deleted_history(&user).await;
+    let deleted = db.deleted_history(&user).await.unwrap_or(vec![]);
 
-    if history_count.is_err() || deleted.is_err() {
-        return Err(ErrorResponse::reply("failed to query history count")
-            .with_status(StatusCode::INTERNAL_SERVER_ERROR));
-    }
+    let count = match db.count_history_cached(&user).await {
+        // By default read out the cached value
+        Ok(count) => count,
+
+        // If that fails, fallback on a full COUNT. Cache is built on a POST
+        // only
+        Err(_) => match db.count_history(&user).await {
+            Ok(count) => count,
+            Err(_) => return Err(ErrorResponse::reply("failed to query history count")
+                .with_status(StatusCode::INTERNAL_SERVER_ERROR)),
+        },
+    };
 
     Ok(Json(StatusResponse {
-        count: history_count.unwrap(),
-        deleted: deleted.unwrap(),
+        count: count,
+        deleted: deleted,
     }))
 }

--- a/atuin-server/src/handlers/status.rs
+++ b/atuin-server/src/handlers/status.rs
@@ -24,13 +24,12 @@ pub async fn status<DB: Database>(
         // only
         Err(_) => match db.count_history(&user).await {
             Ok(count) => count,
-            Err(_) => return Err(ErrorResponse::reply("failed to query history count")
-                .with_status(StatusCode::INTERNAL_SERVER_ERROR)),
+            Err(_) => {
+                return Err(ErrorResponse::reply("failed to query history count")
+                    .with_status(StatusCode::INTERNAL_SERVER_ERROR))
+            }
         },
     };
 
-    Ok(Json(StatusResponse {
-        count: count,
-        deleted: deleted,
-    }))
+    Ok(Json(StatusResponse { count, deleted }))
 }


### PR DESCRIPTION
Thanks for finding this @YummyOreo!

tl;dr is that we have a count cache, as postgres isn't a great column store. This cache is built when a user pushes up history - if the user is new, they have not pushed up history. With the old endpoint, we fell back to a full count (this would only ever be needed once). 