### PR TITLE
Fixes nushell recording empty commands

### DIFF
--- a/src/shell/atuin.nu
+++ b/src/shell/atuin.nu
@@ -6,6 +6,9 @@ let ATUIN_KEYBINDING_TOKEN = $"# (random uuid)"
 
 let _atuin_pre_execution = {||
     let cmd = (commandline)
+    if ($cmd | is-empty) {
+        return
+    }
     if not ($cmd | str starts-with $ATUIN_KEYBINDING_TOKEN) {
         let-env ATUIN_HISTORY_ID = (atuin history start -- $cmd)
     }


### PR DESCRIPTION
If you would press `Enter` it would record it. I don't think that this is intended.