### PR TITLE
fix: record negative exit codes

### DIFF
--- a/src/shell/atuin.nu
+++ b/src/shell/atuin.nu
@@ -20,7 +20,7 @@ let _atuin_pre_prompt = {||
         return
     }
     with-env { RUST_LOG: error } {
-        atuin history end --exit $last_exit -- $env.ATUIN_HISTORY_ID | null
+        atuin history end $'--exit=($last_exit)' -- $env.ATUIN_HISTORY_ID | null
     }
 }
 


### PR DESCRIPTION
Without the `=` I get the error on pressing `Ctrl + C`:

```
error: Found argument '-1' which wasn't expected, or isn't valid in this context

  If you tried to supply '-1' as a value rather than a flag, use '-- -1'

Usage: atuin history end --exit <EXIT> <ID>

For more information try '--help'
```