### PR TITLE
Refactor/nu remove dep on sh

### DIFF
--- a/src/shell/atuin.nu
+++ b/src/shell/atuin.nu
@@ -28,9 +28,9 @@ def _atuin_search_cmd [...flags: string] {
     [
         $ATUIN_KEYBINDING_TOKEN,
         ([
-            `commandline (sh -c 'RUST_LOG=error atuin search`,
-            $flags,
-            `-i -- "$0" 3>&1 1>&2 2>&3' (commandline))`,
+            `commandline (RUST_LOG=error run-external --redirect-stderr atuin search`,
+            ($flags | append [--interactive, --] | each {|e| $'"($e)"'}),
+            `(commandline) | complete | $in.stderr | str substring ',-1')`,
         ] | flatten | str join ' '),
     ] | str join "\n"
 }

--- a/src/shell/atuin.nu
+++ b/src/shell/atuin.nu
@@ -28,10 +28,10 @@ def _atuin_search_cmd [...flags: string] {
     [
         $ATUIN_KEYBINDING_TOKEN,
         ([
-            `commandline (sh -c 'RUST_LOG=error atuin search `,
+            `commandline (sh -c 'RUST_LOG=error atuin search`,
             $flags,
-            ` -i -- "$0" 3>&1 1>&2 2>&3' (commandline))`,
-        ] | flatten | str join ''),
+            `-i -- "$0" 3>&1 1>&2 2>&3' (commandline))`,
+        ] | flatten | str join ' '),
     ] | str join "\n"
 }
 


### PR DESCRIPTION
Remove dependency on `sh` per [The `complete` command doesn't work with interactive commands · Issue #8539 · nushell/nushell](https://github.com/nushell/nushell/issues/8539).