### PR TITLE
Add `--offset` flag to `atuin search`

### DIFF
--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -34,6 +34,7 @@ pub struct OptFilters {
     pub before: Option<String>,
     pub after: Option<String>,
     pub limit: Option<i64>,
+    pub offset: Option<i64>,
 }
 
 pub fn current_context() -> Context {
@@ -359,6 +360,10 @@ impl Database for Sqlite {
 
         if let Some(limit) = filter_options.limit {
             sql.limit(limit);
+        }
+
+        if let Some(offset) = filter_options.offset {
+            sql.offset(offset);
         }
 
         match filter {

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -49,6 +49,10 @@ pub struct Cmd {
     #[arg(long)]
     limit: Option<i64>,
 
+    /// Offset from the start of the results
+    #[arg(long)]
+    offset: Option<i64>,
+
     /// Open interactive search UI
     #[arg(long, short)]
     interactive: bool,
@@ -111,6 +115,7 @@ impl Cmd {
                 before: self.before,
                 after: self.after,
                 limit: self.limit,
+                offset: self.offset,
             };
 
             let mut entries =


### PR DESCRIPTION
This flag allows the user to continue searching at an offset. This is useful for building tools that use atuin to search for previous commands and return only one result.

```
# assuming atuin isn't recording the next few commands..

# return first result for "ssh"
atuin search --limit 1
# return second result
atuin search --limit 1 --offset 1
# so on..
atuin search --limit 1 --offset 2
```