### PR TITLE
install.sh - add endeavouros to archlinux detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -89,7 +89,7 @@ __atuin_install_linux(){
   else
     OS=$(lsb_release -i | awk '{ print $3 }' | tr '[:upper:]' '[:lower:]')
   fi
-	if [ "$OS" == "arch" ] || [ "$OS" == "manjarolinux" ]; then
+	if [ "$OS" == "arch" ] || [ "$OS" == "manjarolinux" ] || [ "$OS" == "endeavouros" ]; then
 		__atuin_install_arch
   elif [ "$OS" == "ubuntu" ] || [ "$OS" == "ubuntuwsl" ] || [ "$OS" == "debian" ] || [ "$OS" == "linuxmint" ] || [ "$OS" == "parrot" ] || [ "$OS" == "kali" ] || [ "$OS" == "elementary" ] || [ "$OS" == "pop" ]; then
 		__atuin_install_ubuntu


### PR DESCRIPTION
[EndeavourOS](https://endeavouros.com/) is a distro based on ArchLinux, like Manjaro Linux.

this simple fix adds it to if condition of installer script.

```bash
$ bash <(curl https://raw.githubusercontent.com/ellie/atuin/main/install.sh)

# omitted

Detected Linux!
Checking distro...
Unknown or unsupported OS
Please check the README at https://github.com/ellie/atuin for manual install instructions
If you have any problems, please open an issue!
Do you wish to attempt an install with 'cargo'? [Y/N] ^C
```

```bash
$ OS=$(lsb_release -i | awk '{ print $3 }' | tr '[:upper:]' '[:lower:]')
$ echo $OS
endeavouros
```