### PR TITLE
feat: add github action to test the nix builds

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,30 @@
+# Verify the Nix build is working
+# Failures will usually occur due to an out of date Rust version
+# That can be updated to the latest version in nixpkgs-unstable with `nix flake update`
+name: Nix
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3.5.0
+      - uses: cachix/install-nix-action@v20
+
+      - name: Run nix flake check
+        run: nix flake check --print-build-logs
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3.5.0
+      - uses: cachix/install-nix-action@v20
+
+      - name: Run nix build
+        run: nix build --print-build-logs


### PR DESCRIPTION
This adds an action that will run a `nix flake check`, which checks the nix configuration, and `nix build`, which builds atuin using the nix config. Failures in this workflow will indicate that flake.lock needs to be updated with `nix flake update` or a change is needed in the configuration files.

This requires #832 to pass. I verified locally using [act](https://github.com/nektos/act) that it succeeds with that change.