### PR TITLE
update `str substring` usage to use range parameter

### DIFF
--- a/src/shell/atuin.nu
+++ b/src/shell/atuin.nu
@@ -30,7 +30,7 @@ def _atuin_search_cmd [...flags: string] {
         ([
             `commandline (RUST_LOG=error run-external --redirect-stderr atuin search`,
             ($flags | append [--interactive, --] | each {|e| $'"($e)"'}),
-            `(commandline) | complete | $in.stderr | str substring ',-1')`,
+            `(commandline) | complete | $in.stderr | str substring ..-1)`,
         ] | flatten | str join ' '),
     ] | str join "\n"
 }


### PR DESCRIPTION
Hi, nushell's `str substring` doesn't accept string argument, I'd like to propose a update to use nushell range instead