### PR TITLE
Fix deleting history that doesn't exist yet

### DIFF
--- a/atuin-client/src/sync.rs
+++ b/atuin-client/src/sync.rs
@@ -95,8 +95,14 @@ async fn sync_download(
     for i in remote_status.deleted {
         // we will update the stored history to have this data
         // pretty much everything can be nullified
-        let h = db.load(i.as_str()).await?;
-        db.delete(h).await?;
+        if let Ok(h) = db.load(i.as_str()).await {
+            db.delete(h).await?;
+        } else {
+            info!(
+                "could not delete history with id {}, not found locally",
+                i.as_str()
+            );
+        }
     }
 
     Ok((local_count - initial_local, local_count))


### PR DESCRIPTION
This can occur if history has been added + then deleted on a machine before it has a chance to be synced to a new one.