### PR TITLE
Add some emacs movement keys

### DIFF
--- a/src/command/client/search/interactive.rs
+++ b/src/command/client/search/interactive.rs
@@ -86,6 +86,7 @@ impl State {
     }
 
     #[allow(clippy::too_many_lines)]
+    #[allow(clippy::cognitive_complexity)]
     fn handle_key_input(
         &mut self,
         settings: &Settings,
@@ -119,18 +120,30 @@ impl State {
                 .search
                 .input
                 .prev_word(&settings.word_chars, settings.word_jump_mode),
+            KeyCode::Char('b') if alt => self
+                .search
+                .input
+                .prev_word(&settings.word_chars, settings.word_jump_mode),
             KeyCode::Left => {
                 self.search.input.left();
             }
             KeyCode::Char('h') if ctrl => {
                 self.search.input.left();
             }
+            KeyCode::Char('b') if ctrl => {
+                self.search.input.left();
+            }
             KeyCode::Right if ctrl => self
+                .search
+                .input
+                .next_word(&settings.word_chars, settings.word_jump_mode),
+            KeyCode::Char('f') if alt => self
                 .search
                 .input
                 .next_word(&settings.word_chars, settings.word_jump_mode),
             KeyCode::Right => self.search.input.right(),
             KeyCode::Char('l') if ctrl => self.search.input.right(),
+            KeyCode::Char('f') if ctrl => self.search.input.right(),
             KeyCode::Char('a') if ctrl => self.search.input.start(),
             KeyCode::Home => self.search.input.start(),
             KeyCode::Char('e') if ctrl => self.search.input.end(),


### PR DESCRIPTION
This adds some common Emacs movement keys. Since Emacs mode is also the default for most shells the keys should be familiar to a lot of people. I kept accidentally adding `f`s and `b`s to the search buffer when trying to jump around ...

I also added an exception for a clippy lint caused by the additional match branches. It's not ideal but I'm not sure breaking up the function would be better.