### PR TITLE
Add `--reverse` to `atuin search`

### DIFF
--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -35,6 +35,7 @@ pub struct OptFilters {
     pub after: Option<String>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
+    pub reverse: bool,
 }
 
 pub fn current_context() -> Context {
@@ -354,9 +355,7 @@ impl Database for Sqlite {
     ) -> Result<Vec<History>> {
         let mut sql = SqlBuilder::select_from("history");
 
-        sql.group_by("command")
-            .having("max(timestamp)")
-            .order_desc("timestamp");
+        sql.group_by("command").having("max(timestamp)");
 
         if let Some(limit) = filter_options.limit {
             sql.limit(limit);
@@ -364,6 +363,12 @@ impl Database for Sqlite {
 
         if let Some(offset) = filter_options.offset {
             sql.offset(offset);
+        }
+
+        if filter_options.reverse {
+            sql.order_asc("timestamp");
+        } else {
+            sql.order_desc("timestamp");
         }
 
         match filter {

--- a/docs/docs/commands/search.md
+++ b/docs/docs/commands/search.md
@@ -22,6 +22,7 @@ appended with a wildcard).
 | `--limit`          | Limit the number of results (default: none)                                   |
 | `--offset`         | Offset from the start of the results (default: none)                          |
 | `--delete`         | Delete history matching this query                                            |
+| `--reverse`        | Reverse order of search results, oldest first |
 
 ## Examples
 
@@ -48,5 +49,8 @@ atuin search --delete --exit 0 --after "yesterday 3pm" cargo
 atuin search --limit 1 cargo
 
 # Search for a single result for a command beginning with cargo, skipping (offsetting) one result
-atuin search --offset 1 --limit cargo
+atuin search --offset 1 --limit 1 cargo
+
+# Find the oldest cargo command
+atuin search --limit 1 --reverse cargo
 ```

--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -83,6 +83,10 @@ pub struct Cmd {
     #[arg(long)]
     delete: bool,
 
+    /// Reverse the order of results, oldest first
+    #[arg(long, short)]
+    reverse: bool,
+
     /// Available variables: {command}, {directory}, {duration}, {user}, {host}, {time}, {exit} and
     /// {relativetime}.
     /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
@@ -116,6 +120,7 @@ impl Cmd {
                 after: self.after,
                 limit: self.limit,
                 offset: self.offset,
+                reverse: self.reverse,
             };
 
             let mut entries =


### PR DESCRIPTION
Add `-r/--reverse` flag to `atuin search` to allow searching by oldest results first.

Example to find the oldest `cargo` command:
```
atuin search --limit 1 --reverse cargo
```