### PR TITLE
Input bar at the top if we are in inline mode

### DIFF
--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -147,6 +147,7 @@ pub struct Settings {
     pub filter_mode_shell_up_key_binding: Option<FilterMode>,
     pub shell_up_key_binding: bool,
     pub inline_height: u16,
+    pub invert: bool,
     pub show_preview: bool,
     pub exit_mode: ExitMode,
     pub word_jump_mode: WordJumpMode,

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -337,6 +337,7 @@ impl Settings {
             .set_default("style", "auto")?
             .set_default("inline_height", 0)?
             .set_default("show_preview", false)?
+            .set_default("invert", false)?
             .set_default("exit_mode", "return-original")?
             .set_default("word_jump_mode", "emacs")?
             .set_default(

--- a/atuin/src/command/client/search/history_list.rs
+++ b/atuin/src/command/client/search/history_list.rs
@@ -13,6 +13,7 @@ use super::format_duration;
 pub struct HistoryList<'a> {
     history: &'a [History],
     block: Option<Block<'a>>,
+    inverted: bool,
 }
 
 #[derive(Default)]
@@ -61,6 +62,7 @@ impl<'a> StatefulWidget for HistoryList<'a> {
             x: 0,
             y: 0,
             state,
+            inverted: self.inverted,
         };
 
         for item in self.history.iter().skip(state.offset).take(end - start) {
@@ -77,10 +79,11 @@ impl<'a> StatefulWidget for HistoryList<'a> {
 }
 
 impl<'a> HistoryList<'a> {
-    pub fn new(history: &'a [History]) -> Self {
+    pub fn new(history: &'a [History], inverted: bool) -> Self {
         Self {
             history,
             block: None,
+            inverted,
         }
     }
 
@@ -110,6 +113,7 @@ struct DrawState<'a> {
     x: u16,
     y: u16,
     state: &'a ListState,
+    inverted: bool,
 }
 
 // longest line prefix I could come up with
@@ -176,7 +180,13 @@ impl DrawState<'_> {
 
     fn draw(&mut self, s: &str, style: Style) {
         let cx = self.list_area.left() + self.x;
-        let cy = self.list_area.bottom() - self.y - 1;
+
+        let cy = if self.inverted {
+            self.list_area.top() + self.y
+        } else {
+            self.list_area.bottom() - self.y - 1
+        };
+
         let w = (self.list_area.width - self.x) as usize;
         self.x += self.buf.set_stringn(cx, cy, s, w, style).0 - cx;
     }


### PR DESCRIPTION
After merging this, I'm working on configurable UI before v15

The idea there is that we can control much more than just compact etc, and toggle each part of the UI to preference. Including where the input bar is

Thanks @pdecat for most of the work here! Based this off of #808 

This does feel kinda weird with the up arrow binding