### PR TITLE
Improve error message for issue #850.

### DIFF
--- a/atuin-client/src/import/zsh.rs
+++ b/atuin-client/src/import/zsh.rs
@@ -32,7 +32,11 @@ fn default_histpath() -> Result<PathBuf> {
                     break Ok(histpath);
                 }
             }
-            None => break Err(eyre!("Could not find history file. Try setting and exporting $HISTFILE")),
+            None => {
+                break Err(eyre!(
+                    "Could not find history file. Try setting and exporting $HISTFILE"
+                ))
+            }
         }
     }
 }

--- a/atuin-client/src/import/zsh.rs
+++ b/atuin-client/src/import/zsh.rs
@@ -32,7 +32,7 @@ fn default_histpath() -> Result<PathBuf> {
                     break Ok(histpath);
                 }
             }
-            None => break Err(eyre!("Could not find history file. Try setting $HISTFILE")),
+            None => break Err(eyre!("Could not find history file. Try setting and exporting $HISTFILE")),
         }
     }
 }


### PR DESCRIPTION
I just had the same thing as the person in issue #850: I hadn't exported my $HISTFILE variable (which I think is probably not an uncommon thing to do; for users who *don't* use atuin it's usually only the shell, not other programs, that interact with the history file). I was able to find the github issue that described it, but figured it would be helpful to include this suggestion in the error message.