### PR TITLE
Avoid accidentally deleting all history, but allow it if intended

### DIFF
--- a/atuin/src/command/client/search.rs
+++ b/atuin/src/command/client/search.rs
@@ -83,6 +83,10 @@ pub struct Cmd {
     #[arg(long)]
     delete: bool,
 
+    /// Delete anything matching this query. Will not print out the match
+    #[arg(long)]
+    delete_it_all: bool,
+
     /// Reverse the order of results, oldest first
     #[arg(long, short)]
     reverse: bool,
@@ -96,6 +100,18 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(self, mut db: impl Database, settings: &mut Settings) -> Result<()> {
+        if self.delete && self.query.is_empty() {
+            println!("Please specify a query to match the items you wish to delete. If you wish to delete all history, pass --delete-it-all");
+            return Ok(());
+        }
+
+        if self.delete_it_all && !self.query.is_empty() {
+            println!(
+                "--delete-it-all will delete ALL of your history! It does not require a query."
+            );
+            return Ok(());
+        }
+
         if self.search_mode.is_some() {
             settings.search_mode = self.search_mode.unwrap();
         }
@@ -131,7 +147,7 @@ impl Cmd {
             }
 
             // if we aren't deleting, print it all
-            if self.delete {
+            if self.delete || self.delete_it_all {
                 // delete it
                 // it only took me _years_ to add this
                 // sorry

--- a/atuin/src/command/client/search.rs
+++ b/atuin/src/command/client/search.rs
@@ -83,7 +83,7 @@ pub struct Cmd {
     #[arg(long)]
     delete: bool,
 
-    /// Delete anything matching this query. Will not print out the match
+    /// Delete EVERYTHING!
     #[arg(long)]
     delete_it_all: bool,
 

--- a/docs/docs/commands/search.md
+++ b/docs/docs/commands/search.md
@@ -22,6 +22,7 @@ appended with a wildcard).
 | `--limit`          | Limit the number of results (default: none)                                   |
 | `--offset`         | Offset from the start of the results (default: none)                          |
 | `--delete`         | Delete history matching this query                                            |
+| `--delete-it-all`         | Delete all shell history |
 | `--reverse`        | Reverse order of search results, oldest first |
 
 ## `atuin search -i`


### PR DESCRIPTION
It would make more sense to have an "atuin delete" or something for blowing away the whole lot. But, users will logically conclude that passing --delete with no query should delete the lot. So this puts a much more explicit switch to do what they want in the same place.