### PR TITLE
Re-added package name to workspace.package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = ["atuin", "atuin-client", "atuin-server", "atuin-common"]
 
 [workspace.package]
+name = "atuin"
 version = "14.0.1"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 rust-version = "1.59"


### PR DESCRIPTION
The package name was removed when `cargo.toml` was refactored to use `workspace.package`. This breaks the binary builds in actions, which depend on this key to generate a package name.

Re-add package name under `workspace.package`