### PR TITLE
Add symlink

### DIFF
--- a/atuin/Cargo.toml
+++ b/atuin/Cargo.toml
@@ -3,7 +3,7 @@ name = "atuin"
 edition = "2021"
 rust-version = "1.59"
 description = "atuin - magical shell history"
-readme = "../README.md"
+readme = "./README.md"
 
 version = { workspace = true }
 authors = { workspace = true }

--- a/atuin/README.md
+++ b/atuin/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
Neither cargo-deb nor Cargo seem to like relative README paths to a parent dir. Using a symlink _does_ work

See https://github.com/kornelski/cargo-deb/pull/62, https://github.com/rust-lang/cargo/issues/5911