### PR TITLE
cwd_filter: much like history_filter, only it applies to cwd

### DIFF
--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -73,3 +73,12 @@
 #   "^secret-cmd",
 #   "^innocuous-cmd .*--secret=.+"
 # ]
+
+## prevent commands run with cwd matching any of these regexes from being written
+## to history. Note that these regular expressions are unanchored, i.e. if they don't
+## start with ^ or end with $, they'll match anyware in CWD.
+## For details on the supported regular expression syntax, see
+## https://docs.rs/regex/latest/regex/#syntax
+# cwd_filter = [
+#   "^/very/secret/area"
+# ]

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -154,6 +154,8 @@ pub struct Settings {
     pub scroll_context_lines: usize,
     #[serde(with = "serde_regex", default = "RegexSet::empty")]
     pub history_filter: RegexSet,
+    #[serde(with = "serde_regex", default = "RegexSet::empty")]
+    pub cwd_filter: RegexSet,
 
     // This is automatically loaded when settings is created. Do not set in
     // config! Keep secrets and settings apart.

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -190,6 +190,9 @@ impl Cmd {
                 // It's better for atuin to silently fail here and attempt to
                 // store whatever is ran, than to throw an error to the terminal
                 let cwd = utils::get_current_dir();
+                if cwd.len() > 0 && settings.cwd_filter.is_match(&cwd) {
+                    return Ok(());
+                }
 
                 let h = History::new(chrono::Utc::now(), command, cwd, -1, -1, None, None, None);
 

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -190,7 +190,7 @@ impl Cmd {
                 // It's better for atuin to silently fail here and attempt to
                 // store whatever is ran, than to throw an error to the terminal
                 let cwd = utils::get_current_dir();
-                if cwd.len() > 0 && settings.cwd_filter.is_match(&cwd) {
+                if !cwd.is_empty() && settings.cwd_filter.is_match(&cwd) {
                     return Ok(());
                 }
 


### PR DESCRIPTION
Minor feature, steal/copy history_filter and apply it to cwd.