### PR TITLE
Add command flag for `inline_height`

### DIFF
--- a/atuin/src/command/client/search.rs
+++ b/atuin/src/command/client/search.rs
@@ -96,6 +96,10 @@ pub struct Cmd {
     /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
     #[arg(long, short)]
     format: Option<String>,
+
+    /// Set the maximum number of lines Atuin's interface should take up.
+    #[arg(long = "inline-height")]
+    inline_height: Option<u16>,
 }
 
 impl Cmd {
@@ -117,6 +121,9 @@ impl Cmd {
         }
         if self.filter_mode.is_some() {
             settings.filter_mode = self.filter_mode.unwrap();
+        }
+        if self.inline_height.is_some() {
+            settings.inline_height = self.inline_height.unwrap();
         }
 
         settings.shell_up_key_binding = self.shell_up_key_binding;


### PR DESCRIPTION
This PR adds the flag `--inline-height <INLINE_HEIGHT>` to the `search` subcommand.
It only applies for interactive mode, should this be added to the help text?
I suppose the "number of lines" is hint enough that it expects an integer value, right?