### PR TITLE
docs: fix "From source" `cd` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ And then follow [the shell setup](#shell-plugin)
 
 ```
 git clone https://github.com/ellie/atuin.git
-cd atuin
+cd atuin/atuin
 cargo install --path .
 ```
   

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -149,7 +149,7 @@ And then follow [the shell setup](#shell-plugin)
 
 ```
 git clone https://github.com/ellie/atuin.git
-cd atuin
+cd atuin/atuin
 cargo install --path .
 ```
   

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -167,7 +167,7 @@ pacman -S atuin
 
 ```
 git clone https://github.com/ellie/atuin.git
-cd atuin
+cd atuin/atuin
 cargo install --path .
 ```
 


### PR DESCRIPTION
Cloning does not automatically cd to the new directory, and we need to cd to "atuin" *inside* the cloned repository.

(Thanks to @YummyOreo for [pointing this out](https://github.com/ellie/atuin/issues/934#issuecomment-1535565743))