### PR TITLE
Correct typos in website

### DIFF
--- a/docs/docs/commands/search.md
+++ b/docs/docs/commands/search.md
@@ -24,7 +24,7 @@ appended with a wildcard).
 | `--delete`           | Delete history matching this query                                            |
 | `--delete-it-all`    | Delete all shell history                                                      |
 | `--reverse`          | Reverse order of search results, oldest first                                 |
-| `--format`/`-f`      | Available vareables: {command}, {directory}, {duration}, {user}, {host}, {time}, {exit} and {relativetime}. Example: --format "{time} - [{duration}] - {directory}$\t{command}" |
+| `--format`/`-f`      | Available variables: {command}, {directory}, {duration}, {user}, {host}, {time}, {exit} and {relativetime}. Example: --format "{time} - [{duration}] - {directory}$\t{command}" |
 | `--inline-height`    | Set the maximum number of lines Atuin's interface should take up              |
 | `--help`/`-h`        | Print help                                                                    |
 

--- a/docs/docs/config/key-binding.md
+++ b/docs/docs/config/key-binding.md
@@ -16,7 +16,7 @@ eval "$(atuin init zsh --disable-ctrl-r)"
 ```
 
 If you do not want either key to be bound, either pass both `--disable` arguments, or set the
-environment varuable `ATUIN_NOBIND` to any value before the call to `atuin init`:
+environment variable `ATUIN_NOBIND` to any value before the call to `atuin init`:
 
 ```
 ## Do not bind any keys


### PR DESCRIPTION
This commit fixes the spelling of "variables" in a couple of places.