### PR TITLE
At least patch this on the server side so we don't loop forever

### DIFF
--- a/atuin-client/src/import/bash.rs
+++ b/atuin-client/src/import/bash.rs
@@ -62,7 +62,7 @@ impl Importer for Bash {
         // this increment is deliberately very small to prevent particularly fast fingers
         // causing ordering issues; it also helps in handling the "here document" syntax,
         // where several lines are recorded in succession without individual timestamps
-        let timestamp_increment = Duration::nanoseconds(1);
+        let timestamp_increment = Duration::milliseconds(1);
 
         // make sure there is a minimum amount of time before the first known timestamp
         // to fit all commands, given the default increment

--- a/atuin-server/src/handlers/history.rs
+++ b/atuin-server/src/handlers/history.rs
@@ -53,6 +53,14 @@ pub async fn list<DB: Database>(
         )
         .await;
 
+    if req.sync_ts.timestamp_nanos() < 0 || req.history_ts.timestamp_nanos() < 0 {
+        error!("client asked for history from < epoch 0");
+        return Err(
+            ErrorResponse::reply("asked for history from before epoch 0")
+                .with_status(StatusCode::BAD_REQUEST),
+        );
+    }
+
     if let Err(e) = history {
         error!("failed to load history: {}", e);
         return Err(ErrorResponse::reply("failed to load history")


### PR DESCRIPTION
#845 introduced a regression where we could loop forever when trying to sync bash history

This is because the server uses the postgres-native timestamp type, which only supports up-to microsecond precision. Incrementing by nanoseconds here meant that to the query, all history had the same timestamp. no bueno!

Use millis instead. They're likely to be safer for all future data processing, and are still faster than a human can spam a button,