### PR TITLE
feat: add delete account option (attempt 2)

### DIFF
--- a/atuin-client/src/api_client.rs
+++ b/atuin-client/src/api_client.rs
@@ -222,10 +222,7 @@ impl<'a> Client<'a> {
         let url = format!("{}/register", self.sync_addr);
         let url = Url::parse(url.as_str())?;
 
-        let resp = self.client
-            .delete(url)
-            .send()
-            .await?;
+        let resp = self.client.delete(url).send().await?;
 
         if resp.status() == 403 {
             bail!("invalid login details");

--- a/atuin-client/src/api_client.rs
+++ b/atuin-client/src/api_client.rs
@@ -218,7 +218,7 @@ impl<'a> Client<'a> {
         Ok(())
     }
 
-    pub async fn unregister(&self) -> Result<()> {
+    pub async fn delete(&self) -> Result<()> {
         let url = format!("{}/register", self.sync_addr);
         let url = Url::parse(url.as_str())?;
 

--- a/atuin-client/src/api_client.rs
+++ b/atuin-client/src/api_client.rs
@@ -217,4 +217,22 @@ impl<'a> Client<'a> {
 
         Ok(())
     }
+
+    pub async fn unregister(&self) -> Result<()> {
+        let url = format!("{}/register", self.sync_addr);
+        let url = Url::parse(url.as_str())?;
+
+        let resp = self.client
+            .delete(url)
+            .send()
+            .await?;
+
+        if resp.status() == 403 {
+            bail!("invalid login details");
+        } else if resp.status() == 200 {
+            Ok(())
+        } else {
+            bail!("Unknown error");
+        }
+    }
 }

--- a/atuin-common/src/api.rs
+++ b/atuin-common/src/api.rs
@@ -20,6 +20,10 @@ pub struct RegisterResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct UnregisterResponse {
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LoginRequest {
     pub username: String,
     pub password: String,

--- a/atuin-common/src/api.rs
+++ b/atuin-common/src/api.rs
@@ -20,7 +20,7 @@ pub struct RegisterResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct UnregisterResponse {
+pub struct DeleteUserResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/atuin-common/src/api.rs
+++ b/atuin-common/src/api.rs
@@ -20,8 +20,7 @@ pub struct RegisterResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct DeleteUserResponse {
-}
+pub struct DeleteUserResponse {}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LoginRequest {

--- a/atuin-server/src/database.rs
+++ b/atuin-server/src/database.rs
@@ -339,19 +339,19 @@ impl Database for Postgres {
 
     #[instrument(skip_all)]
     async fn delete_user(&self, u: &User) -> Result<()> {
-        sqlx::query_as::<_, Session>("delete from sessions where user_id = $1")
+        sqlx::query("delete from sessions where user_id = $1")
             .bind(u.id)
-            .fetch_all(&self.pool)
+            .execute(&self.pool)
             .await?;
 
-        sqlx::query_as::<_, Session>("delete from users where id = $1")
+        sqlx::query("delete from users where id = $1")
             .bind(u.id)
-            .fetch_all(&self.pool)
+            .execute(&self.pool)
             .await?;
 
-        sqlx::query_as::<_, Session>("delete from history where user_id = $1")
+        sqlx::query("delete from history where user_id = $1")
             .bind(u.id)
-            .fetch_all(&self.pool)
+            .execute(&self.pool)
             .await?;
 
         Ok(())

--- a/atuin-server/src/database.rs
+++ b/atuin-server/src/database.rs
@@ -27,7 +27,7 @@ pub trait Database {
     async fn get_user(&self, username: &str) -> Result<User>;
     async fn get_user_session(&self, u: &User) -> Result<Session>;
     async fn add_user(&self, user: &NewUser) -> Result<i64>;
-    async fn remove_user(&self, u: &User) -> Result<()>;
+    async fn delete_user(&self, u: &User) -> Result<()>;
 
     async fn count_history(&self, user: &User) -> Result<i64>;
     async fn count_history_cached(&self, user: &User) -> Result<i64>;
@@ -338,7 +338,7 @@ impl Database for Postgres {
     }
 
     #[instrument(skip_all)]
-    async fn remove_user(&self, u: &User) -> Result<()> {
+    async fn delete_user(&self, u: &User) -> Result<()> {
         sqlx::query_as::<_, Session>("delete from sessions where user_id = $1")
             .bind(u.id)
             .fetch_all(&self.pool)

--- a/atuin-server/src/handlers/user.rs
+++ b/atuin-server/src/handlers/user.rs
@@ -139,20 +139,20 @@ pub async fn register<DB: Database>(
 }
 
 #[instrument(skip_all, fields(user.id = user.id))]
-pub async fn unregister<DB: Database>(
+pub async fn delete<DB: Database>(
     user: User,
     state: State<AppState<DB>>,
-) -> Result<Json<UnregisterResponse>, ErrorResponseStatus<'static>> {
-    debug!("request to remove user {}", user.id);
+) -> Result<Json<DeleteUserResponse>, ErrorResponseStatus<'static>> {
+    debug!("request to delete user {}", user.id);
 
     let db = &state.0.database;
-    if let Err(e) = db.remove_user(&user).await {
-        error!("failed to remove user: {}", e);
+    if let Err(e) = db.delete_user(&user).await {
+        error!("failed to delete user: {}", e);
 
-        return Err(ErrorResponse::reply("failed to add history")
+        return Err(ErrorResponse::reply("failed to delete user")
             .with_status(StatusCode::INTERNAL_SERVER_ERROR));
     };
-    Ok(Json(UnregisterResponse { }))
+    Ok(Json(DeleteUserResponse { }))
 }
 
 #[instrument(skip_all, fields(user.username = login.username.as_str()))]

--- a/atuin-server/src/handlers/user.rs
+++ b/atuin-server/src/handlers/user.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 use super::{ErrorResponse, ErrorResponseStatus, RespExt};
 use crate::{
     database::Database,
-    models::{NewSession, NewUser},
+    models::{NewSession, NewUser, User},
     router::AppState,
 };
 
@@ -136,6 +136,16 @@ pub async fn register<DB: Database>(
                 .with_status(StatusCode::BAD_REQUEST))
         }
     }
+}
+
+#[instrument(skip_all, fields(user.id = user.id))]
+pub async fn unregister<DB: Database>(
+    user: User,
+    state: State<AppState<DB>>,
+) -> Result<Json<UnregisterResponse>, ErrorResponseStatus<'static>> {
+    debug!("request to remove user {}", user.id);
+
+    Ok(Json(UnregisterResponse { }))
 }
 
 #[instrument(skip_all, fields(user.username = login.username.as_str()))]

--- a/atuin-server/src/handlers/user.rs
+++ b/atuin-server/src/handlers/user.rs
@@ -152,7 +152,7 @@ pub async fn delete<DB: Database>(
         return Err(ErrorResponse::reply("failed to delete user")
             .with_status(StatusCode::INTERNAL_SERVER_ERROR));
     };
-    Ok(Json(DeleteUserResponse { }))
+    Ok(Json(DeleteUserResponse {}))
 }
 
 #[instrument(skip_all, fields(user.username = login.username.as_str()))]

--- a/atuin-server/src/handlers/user.rs
+++ b/atuin-server/src/handlers/user.rs
@@ -145,6 +145,13 @@ pub async fn unregister<DB: Database>(
 ) -> Result<Json<UnregisterResponse>, ErrorResponseStatus<'static>> {
     debug!("request to remove user {}", user.id);
 
+    let db = &state.0.database;
+    if let Err(e) = db.remove_user(&user).await {
+        error!("failed to remove user: {}", e);
+
+        return Err(ErrorResponse::reply("failed to add history")
+            .with_status(StatusCode::INTERNAL_SERVER_ERROR));
+    };
     Ok(Json(UnregisterResponse { }))
 }
 

--- a/atuin-server/src/router.rs
+++ b/atuin-server/src/router.rs
@@ -72,7 +72,7 @@ pub fn router<DB: Database + Clone + Send + Sync + 'static>(
         .route("/history", post(handlers::history::add))
         .route("/history", delete(handlers::history::delete))
         .route("/user/:username", get(handlers::user::get))
-        .route("/register", delete(handlers::user::unregister))
+        .route("/account", delete(handlers::user::delete))
         .route("/register", post(handlers::user::register))
         .route("/login", post(handlers::user::login));
 

--- a/atuin-server/src/router.rs
+++ b/atuin-server/src/router.rs
@@ -72,6 +72,7 @@ pub fn router<DB: Database + Clone + Send + Sync + 'static>(
         .route("/history", post(handlers::history::add))
         .route("/history", delete(handlers::history::delete))
         .route("/user/:username", get(handlers::user::get))
+        .route("/register", delete(handlers::user::unregister))
         .route("/register", post(handlers::user::register))
         .route("/login", post(handlers::user::login));
 

--- a/atuin/src/command/client/sync.rs
+++ b/atuin/src/command/client/sync.rs
@@ -3,10 +3,10 @@ use eyre::{Result, WrapErr};
 
 use atuin_client::{database::Database, settings::Settings};
 
+mod delete;
 mod login;
 mod logout;
 mod register;
-mod delete;
 mod status;
 
 #[derive(Subcommand)]

--- a/atuin/src/command/client/sync.rs
+++ b/atuin/src/command/client/sync.rs
@@ -6,6 +6,7 @@ use atuin_client::{database::Database, settings::Settings};
 mod login;
 mod logout;
 mod register;
+mod unregister;
 mod status;
 
 #[derive(Subcommand)]
@@ -27,6 +28,9 @@ pub enum Cmd {
     /// Register with the configured server
     Register(register::Cmd),
 
+    /// Unregister with the configured server
+    Unregister,
+
     /// Print the encryption key for transfer to another machine
     Key {
         /// Switch to base64 output of the key
@@ -44,6 +48,7 @@ impl Cmd {
             Self::Login(l) => l.run(&settings).await,
             Self::Logout => logout::run(&settings),
             Self::Register(r) => r.run(&settings).await,
+            Self::Unregister => unregister::run(&settings).await,
             Self::Status => status::run(&settings, db).await,
             Self::Key { base64 } => {
                 use atuin_client::encryption::{encode_key, load_key};

--- a/atuin/src/command/client/sync.rs
+++ b/atuin/src/command/client/sync.rs
@@ -6,7 +6,7 @@ use atuin_client::{database::Database, settings::Settings};
 mod login;
 mod logout;
 mod register;
-mod unregister;
+mod delete;
 mod status;
 
 #[derive(Subcommand)]
@@ -48,7 +48,7 @@ impl Cmd {
             Self::Login(l) => l.run(&settings).await,
             Self::Logout => logout::run(&settings),
             Self::Register(r) => r.run(&settings).await,
-            Self::Unregister => unregister::run(&settings).await,
+            Self::Unregister => delete::run(&settings).await,
             Self::Status => status::run(&settings, db).await,
             Self::Key { base64 } => {
                 use atuin_client::encryption::{encode_key, load_key};

--- a/atuin/src/command/client/sync/delete.rs
+++ b/atuin/src/command/client/sync/delete.rs
@@ -17,7 +17,7 @@ pub async fn run(settings: &Settings) -> Result<()> {
         load_encoded_key(settings)?,
     )?;
 
-    client.unregister().await?;
+    client.delete().await?;
 
     println!("Your account is deleted");
 

--- a/atuin/src/command/client/sync/delete.rs
+++ b/atuin/src/command/client/sync/delete.rs
@@ -1,8 +1,6 @@
-use std::path::PathBuf;
+use atuin_client::{api_client, encryption::load_encoded_key, settings::Settings};
 use eyre::{bail, Result};
-use atuin_client::{
-    api_client, encryption::load_encoded_key, settings::Settings,
-};
+use std::path::PathBuf;
 
 pub async fn run(settings: &Settings) -> Result<()> {
     let session_path = settings.session_path.as_str();

--- a/atuin/src/command/client/sync/unregister.rs
+++ b/atuin/src/command/client/sync/unregister.rs
@@ -1,0 +1,25 @@
+use std::path::PathBuf;
+use eyre::{bail, Result};
+use atuin_client::{
+    api_client, encryption::load_encoded_key, settings::Settings,
+};
+
+pub async fn run(settings: &Settings) -> Result<()> {
+    let session_path = settings.session_path.as_str();
+
+    if !PathBuf::from(session_path).exists() {
+        bail!("You are not logged in");
+    }
+
+    let client = api_client::Client::new(
+        &settings.sync_address,
+        &settings.session_token,
+        load_encoded_key(settings)?,
+    )?;
+
+    client.unregister().await?;
+
+    println!("Your account is deleted");
+
+    Ok(())
+}

--- a/docs/docs/commands/sync.md
+++ b/docs/docs/commands/sync.md
@@ -32,7 +32,7 @@ notifications (security breaches, changes to service, etc).
 Upon success, you are also logged in :) Syncing should happen automatically from
 here!
 
-## Unregister
+## Delete
 
 You can delete your sync account with
 

--- a/docs/docs/commands/sync.md
+++ b/docs/docs/commands/sync.md
@@ -32,6 +32,14 @@ notifications (security breaches, changes to service, etc).
 Upon success, you are also logged in :) Syncing should happen automatically from
 here!
 
+## Unregister
+
+You can delete your sync account with
+
+```
+atuin unregister
+```
+
 ## Key
 
 As all your data is encrypted, Atuin generates a key for you. It's stored in the


### PR DESCRIPTION
This is implementing an account deletion option, similar to #266. I've made the following changes
 * added a `remove_user` function to the database that deletes the user from `users`, `sessions`, and `history`
 * added an API endpoint: currently this is the DELETE handler for the `/register` endpoint but could be moved. If this gets called by a logged in user, the account gets delete
 * added the `unregister` command to the CLI
```shell
$ atuin unregister
```

I'm wondering how we should prevent accidental account deletion. We could ask the user provide their password, email, or username
```shell
$ atuin unregister -e user@example.com
```
Any suggestions? 

PS: Thanks for looking into this and thanks for building this, it's a really cool tool :blush: 