### PR TITLE
Make volume path absolute

### DIFF
--- a/docs/docs/self-hosting/docker.md
+++ b/docs/docs/self-hosting/docker.md
@@ -3,7 +3,7 @@
 There is a supplied docker image to make deploying a server as a container easier.
 
 ```sh
-docker run -d -v "/home/$USER/.config/atuin:/config" ghcr.io/ellie/atuin:latest server start
+docker run -d -v "$HOME/.config/atuin:/config" ghcr.io/ellie/atuin:latest server start
 ```
 
 # Docker Compose

--- a/docs/docs/self-hosting/docker.md
+++ b/docs/docs/self-hosting/docker.md
@@ -3,7 +3,7 @@
 There is a supplied docker image to make deploying a server as a container easier.
 
 ```sh
-docker run -d -v "$USER/.config/atuin:/config" ghcr.io/ellie/atuin:latest server start
+docker run -d -v "/home/$USER/.config/atuin:/config" ghcr.io/ellie/atuin:latest server start
 ```
 
 # Docker Compose


### PR DESCRIPTION
My Docker gave:

```
docker: Error response from daemon: create USER/.config/atuin: "USER/.config/atuin" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
```

-- so decided to make the path absolute. Can't hurt?