### PR TITLE
fix: Adjust broken link to supported shells

### DIFF
--- a/docs/docs/commands/shell-completions.md
+++ b/docs/docs/commands/shell-completions.md
@@ -16,4 +16,4 @@ Possible values for the `--shell` argument are the following:
 - `powershell`
 - `elvish`
 
-Also, see the [supported shells](./../README.md#supported-shells).
+Also, see the [supported shells](./../index.md#supported-shells).


### PR DESCRIPTION
The "supported shells" link [here](https://atuin.sh/docs/commands/shell-completions) pointed to `README.md` instead of [`index.md`](https://github.com/ellie/atuin/blob/main/docs/docs/index.md)