### PR TITLE
Add graceful shutdown on SIGTERM

### DIFF
--- a/atuin-server/src/lib.rs
+++ b/atuin-server/src/lib.rs
@@ -22,9 +22,9 @@ pub mod utils;
 async fn shutdown_signal() {
     let terminate = async {
         signal::unix::signal(signal::unix::SignalKind::terminate())
-        .expect("failed to register signal handler")
-        .recv()
-        .await;
+            .expect("failed to register signal handler")
+            .recv()
+            .await;
     };
 
     tokio::select! {

--- a/atuin-server/src/lib.rs
+++ b/atuin-server/src/lib.rs
@@ -8,6 +8,8 @@ use eyre::{Context, Result};
 
 use crate::settings::Settings;
 
+use tokio::signal;
+
 pub mod auth;
 pub mod calendar;
 pub mod database;
@@ -16,6 +18,20 @@ pub mod models;
 pub mod router;
 pub mod settings;
 pub mod utils;
+
+async fn shutdown_signal() {
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+        .expect("failed to register signal handler")
+        .recv()
+        .await;
+    };
+
+    tokio::select! {
+        _ = terminate => (),
+    }
+    eprintln!("Shutting down gracefully...");
+}
 
 pub async fn launch(settings: Settings, host: String, port: u16) -> Result<()> {
     let host = host.parse::<IpAddr>()?;
@@ -28,6 +44,7 @@ pub async fn launch(settings: Settings, host: String, port: u16) -> Result<()> {
 
     Server::bind(&SocketAddr::new(host, port))
         .serve(r.into_make_service())
+        .with_graceful_shutdown(shutdown_signal())
         .await?;
 
     Ok(())


### PR DESCRIPTION
Closes #676

This is my first significant exposure to Rust in general, especially async. I had to learn a lot of background for these few lines of code lol

Anyways, I tested it with a local docker-compose.yml and it seems to be working
(working =  it does not wait anymore for the timeout and SIGKILL, but it shuts down seemingly immediately with a corresponding message and exit code 0).
![image](https://github.com/ellie/atuin/assets/12953598/f852764e-03a9-421a-8305-8aa04b1fd88c)

Further tests are welcome!