### PR TITLE
Replace CREATE OR REPLACE TRIGGER syntax

### DIFF
--- a/atuin-server/migrations/20230515221038_trigger-delete-only.sql
+++ b/atuin-server/migrations/20230515221038_trigger-delete-only.sql
@@ -24,7 +24,11 @@ $func$
 language plpgsql volatile -- pldfplplpflh
 cost 100; -- default value
 
-create or replace trigger tg_user_history_count 
-	after insert on history 
-	for each row 
-	execute procedure user_history_count();
+begin;
+drop trigger if exists tg_user_history_count on history;
+
+create trigger tg_user_history_count
+        after insert on history
+        for each row
+        execute procedure user_history_count();
+commit;


### PR DESCRIPTION
PostgreSQL 13 doesn't support the `CREATE OR REPLACE TRIGGER` syntax yet. As PostgreSQL 13 was released fairly recently, in September 2020, is still supported and [will be until 2025](https://www.postgresql.org/support/versioning/), it might make sense to use SQL statements that are supported by PostgreSQL 13?

I have rewritten the SQL in the migration to drop the trigger and re-create it, wrapped in a transaction, instead of using the `CREATE OR REPLACE` syntax. This works for me, but I obviously only have a single atuin server instance running.

Background: [PostgreSQL 13 CREATE TRIGGER documentation](https://www.postgresql.org/docs/13/sql-createtrigger.html) does not show the `... OR REPLACE` syntax, while the [PostgreSQL 14 CREATE TRIGGER documentation](https://www.postgresql.org/docs/14/sql-createtrigger.html) does.

Alternatively, the docs might say a minimum of PostgreSQL 14 is required. I would very much prefer supported PostgreSQL 13 as well though.