### PR TITLE
Key values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
  "chrono",
  "rand",
  "serde",
+ "typed-builder",
  "uuid",
 ]
 
@@ -2559,6 +2560,17 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "typed-builder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cba322cb9b7bc6ca048de49e83918223f35e7a86311267013afff257004870"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.99",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ sodiumoxide = "0.2.6"
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1.2", features = ["v4"] }
 whoami = "1.1.2"
+typed-builder = "0.14.0"
 
 [workspace.dependencies.reqwest]
 version = "0.11"

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -18,7 +18,6 @@ sync = [
   "reqwest",
   "sha2",
   "hex",
-  "rmp-serde",
   "base64",
   "generic-array",
   "xsalsa20poly1305",
@@ -50,6 +49,7 @@ fs-err = { workspace = true }
 sql-builder = "3"
 lazy_static = "1"
 memchr = "2.5"
+rmp-serde = { version = "1.1.1" }
 
 # sync
 urlencoding = { version = "2.1.0", optional = true }
@@ -57,7 +57,6 @@ sodiumoxide = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 hex = { version = "0.4", optional = true }
 sha2 = { version = "0.10", optional = true }
-rmp-serde = { version = "1.1.1", optional = true }
 base64 = { workspace = true, optional = true }
 tokio = { workspace = true }
 semver = { workspace = true }

--- a/atuin-client/record-migrations/20230531212437_create-records.sql
+++ b/atuin-client/record-migrations/20230531212437_create-records.sql
@@ -6,5 +6,9 @@ create table if not exists records (
 
   tag text not null,
   version text not null,
-  data blob not null,
+  data blob not null
 );
+
+create index host_idx on records (host);
+create index tag_idx on records (tag);
+create index host_tag_idx on records (host, tag);

--- a/atuin-client/record-migrations/20230531212437_create-records.sql
+++ b/atuin-client/record-migrations/20230531212437_create-records.sql
@@ -1,0 +1,10 @@
+-- Add migration script here
+create table if not exists records (
+  id text primary key,
+  host text not null,
+  timestamp integer not null,
+
+  tag text not null,
+  version text not null,
+  data blob not null,
+);

--- a/atuin-client/record-migrations/20230531212437_create-records.sql
+++ b/atuin-client/record-migrations/20230531212437_create-records.sql
@@ -1,9 +1,10 @@
 -- Add migration script here
 create table if not exists records (
   id text primary key,
+  parent text unique, -- null if this is the first one
   host text not null,
-  timestamp integer not null,
 
+  timestamp integer not null,
   tag text not null,
   version text not null,
   data blob not null

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -543,6 +543,7 @@ mod test {
             hostname: "test:host".to_string(),
             session: "beepboopiamasession".to_string(),
             cwd: "/home/ellie".to_string(),
+            host_id: "test-host".to_string(),
         };
 
         let results = db
@@ -749,6 +750,7 @@ mod test {
             hostname: "test:host".to_string(),
             session: "beepboopiamasession".to_string(),
             cwd: "/home/ellie".to_string(),
+            host_id: "test-host".to_string(),
         };
 
         let mut db = Sqlite::new("sqlite::memory:").await.unwrap();

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -16,13 +16,14 @@ use sqlx::{
 use super::{
     history::History,
     ordering,
-    settings::{FilterMode, SearchMode},
+    settings::{FilterMode, SearchMode, Settings},
 };
 
 pub struct Context {
     pub session: String,
     pub cwd: String,
     pub hostname: String,
+    pub host_id: String,
 }
 
 #[derive(Default, Clone)]
@@ -45,11 +46,13 @@ pub fn current_context() -> Context {
     };
     let hostname = format!("{}:{}", whoami::hostname(), whoami::username());
     let cwd = utils::get_current_dir();
+    let host_id = Settings::host_id().expect("failed to load host ID");
 
     Context {
         session,
         hostname,
         cwd,
+        host_id,
     }
 }
 

--- a/atuin-client/src/kv.rs
+++ b/atuin-client/src/kv.rs
@@ -23,13 +23,24 @@ impl KvRecord {
 
 pub struct KvStore;
 
+impl Default for KvStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl KvStore {
     // will want to init the actual kv store when that is done
     pub fn new() -> KvStore {
         KvStore {}
     }
 
-    pub async fn set(&self, store: &mut impl Store, key: &str, value: &str) -> Result<()> {
+    pub async fn set(
+        &self,
+        store: &mut (impl Store + Send + Sync),
+        key: &str,
+        value: &str,
+    ) -> Result<()> {
         let host_id = Settings::host_id().expect("failed to get host_id");
 
         let record = KvRecord {
@@ -88,6 +99,6 @@ impl KvStore {
         }
 
         // if we get here, then... we didn't find the record with that key :(
-        return Ok(None);
+        Ok(None)
     }
 }

--- a/atuin-client/src/kv.rs
+++ b/atuin-client/src/kv.rs
@@ -1,6 +1,12 @@
 use eyre::Result;
 use serde::{Deserialize, Serialize};
 
+use crate::record::store::Store;
+use crate::settings::Settings;
+
+const KV_VERSION: &str = "v0";
+const KV_TAG: &str = "kv";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KvRecord {
     pub key: String,
@@ -12,5 +18,76 @@ impl KvRecord {
         let buf = rmp_serde::to_vec(self)?;
 
         Ok(buf)
+    }
+}
+
+pub struct KvStore;
+
+impl KvStore {
+    // will want to init the actual kv store when that is done
+    pub fn new() -> KvStore {
+        KvStore {}
+    }
+
+    pub async fn set(&self, store: &mut impl Store, key: &str, value: &str) -> Result<()> {
+        let host_id = Settings::host_id().expect("failed to get host_id");
+
+        let record = KvRecord {
+            key: key.to_string(),
+            value: value.to_string(),
+        };
+
+        let bytes = record.serialize()?;
+
+        let len = store.len(host_id.as_str(), KV_TAG).await?;
+
+        let parent = if len > 0 {
+            Some(store.last(host_id.as_str(), KV_TAG).await?.id)
+        } else {
+            None
+        };
+
+        let record = atuin_common::record::Record::new(
+            host_id,
+            KV_VERSION.to_string(),
+            KV_TAG.to_string(),
+            parent,
+            bytes,
+        );
+
+        store.push(record).await?;
+
+        Ok(())
+    }
+
+    // TODO: setup an actual kv store, rebuild func, and do not pass the main store in here as
+    // well.
+    pub async fn get(&self, store: &impl Store, key: &str) -> Result<Option<KvRecord>> {
+        // TODO: don't load this from disk so much
+        let host_id = Settings::host_id().expect("failed to get host_id");
+
+        // Currently, this is O(n). When we have an actual KV store, it can be better
+        // Just a poc for now!
+
+        // iterate records to find the value we want
+        // start at the end, so we get the most recent version
+        let mut record = store.last(host_id.as_str(), KV_TAG).await?;
+        let kv: KvRecord = rmp_serde::from_slice(&record.data)?;
+
+        if kv.key == key {
+            return Ok(Some(kv));
+        }
+
+        while let Some(parent) = record.parent {
+            record = store.get(parent.as_str()).await?;
+            let kv: KvRecord = rmp_serde::from_slice(&record.data)?;
+
+            if kv.key == key {
+                return Ok(Some(kv));
+            }
+        }
+
+        // if we get here, then... we didn't find the record with that key :(
+        return Ok(None);
     }
 }

--- a/atuin-client/src/kv.rs
+++ b/atuin-client/src/kv.rs
@@ -1,0 +1,16 @@
+use eyre::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct KvRecord {
+    pub key: String,
+    pub value: String,
+}
+
+impl KvRecord {
+    pub fn serialize(&self) -> Result<Vec<u8>> {
+        let buf = rmp_serde::to_vec(self)?;
+
+        Ok(buf)
+    }
+}

--- a/atuin-client/src/lib.rs
+++ b/atuin-client/src/lib.rs
@@ -13,6 +13,7 @@ pub mod sync;
 pub mod database;
 pub mod history;
 pub mod import;
+pub mod kv;
 pub mod ordering;
 pub mod record;
 pub mod settings;

--- a/atuin-client/src/lib.rs
+++ b/atuin-client/src/lib.rs
@@ -14,4 +14,5 @@ pub mod database;
 pub mod history;
 pub mod import;
 pub mod ordering;
+pub mod record;
 pub mod settings;

--- a/atuin-client/src/record/mod.rs
+++ b/atuin-client/src/record/mod.rs
@@ -1,0 +1,2 @@
+pub mod sqlite_store;
+pub mod store;

--- a/atuin-client/src/record/sqlite_store.rs
+++ b/atuin-client/src/record/sqlite_store.rs
@@ -90,12 +90,30 @@ impl SqliteStore {
 #[async_trait]
 impl Store for SqliteStore {
     async fn push(&self, record: Record) -> Result<Record> {
-        // TODO: batch inserts
         let mut tx = self.pool.begin().await?;
         Self::save_raw(&mut tx, &record).await?;
         tx.commit().await?;
 
         Ok(record)
+    }
+
+    async fn push_batch(
+        &self,
+        records: impl Iterator<Item = &Record> + Send + Sync,
+    ) -> Result<Option<Record>> {
+        let mut tx = self.pool.begin().await?;
+
+        // If you push in a batch of nothing it does... nothing.
+        let mut last: Option<Record> = None;
+        for record in records {
+            Self::save_raw(&mut tx, &record).await?;
+
+            last = Some(record.clone());
+        }
+
+        tx.commit().await?;
+
+        Ok(last)
     }
 
     async fn get(&self, id: &str) -> Result<Record> {
@@ -119,9 +137,20 @@ impl Store for SqliteStore {
         Ok(res.0 as u64)
     }
 
+    async fn next(&self, record: &Record) -> Option<Record> {
+        let res = sqlx::query("select * from records where parent = ?1")
+            .bind(record.id.clone())
+            .map(Self::query_row)
+            .fetch_one(&self.pool)
+            .await
+            .ok();
+
+        res
+    }
+
     async fn first(&self, host: &str, tag: &str) -> Result<Record> {
         let res = sqlx::query(
-            "select * from records where tag = ?1 and host = ?2 and parent is null limit 1",
+            "select * from records where host = ?1 and tag = ?2 and parent is null limit 1",
         )
         .bind(host)
         .bind(tag)
@@ -244,5 +273,78 @@ mod tests {
 
         assert_eq!(first_len, 1, "expected length of 1 after insert");
         assert_eq!(second_len, 1, "expected length of 1 after insert");
+    }
+
+    #[tokio::test]
+    async fn append_a_bunch() {
+        let db = SqliteStore::new(":memory:").await.unwrap();
+
+        let mut tail = db.push(test_record()).await.expect("failed to push record");
+
+        for _ in 1..100 {
+            tail = db.push(tail.new_child(vec![1, 2, 3, 4])).await.unwrap();
+        }
+
+        assert_eq!(
+            db.len(tail.host.as_str(), tail.tag.as_str()).await.unwrap(),
+            100,
+            "failed to insert 100 records"
+        );
+    }
+
+    #[tokio::test]
+    async fn append_a_big_bunch() {
+        let db = SqliteStore::new(":memory:").await.unwrap();
+
+        let mut records: Vec<Record> = Vec::with_capacity(10000);
+
+        let mut tail = test_record();
+        records.push(tail.clone());
+
+        for _ in 1..10000 {
+            tail = tail.new_child(vec![1, 2, 3]);
+            records.push(tail.clone());
+        }
+
+        db.push_batch(records.iter()).await.unwrap();
+
+        assert_eq!(
+            db.len(tail.host.as_str(), tail.tag.as_str()).await.unwrap(),
+            10000,
+            "failed to insert 10k records"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_chain() {
+        let db = SqliteStore::new(":memory:").await.unwrap();
+
+        let mut records: Vec<Record> = Vec::with_capacity(1000);
+
+        let mut tail = test_record();
+        records.push(tail.clone());
+
+        for _ in 1..1000 {
+            tail = tail.new_child(vec![1, 2, 3]);
+            records.push(tail.clone());
+        }
+
+        db.push_batch(records.iter()).await.unwrap();
+
+        let mut record = db
+            .first(tail.host.as_str(), tail.tag.as_str())
+            .await
+            .unwrap();
+
+        let mut count = 1;
+
+        while let Some(next) = db.next(&record).await {
+            assert_eq!(record.id, next.clone().parent.unwrap());
+            record = next;
+
+            count += 1;
+        }
+
+        assert_eq!(count, 1000);
     }
 }

--- a/atuin-client/src/record/sqlite_store.rs
+++ b/atuin-client/src/record/sqlite_store.rs
@@ -137,15 +137,14 @@ impl Store for SqliteStore {
         Ok(res.0 as u64)
     }
 
-    async fn next(&self, record: &Record) -> Option<Record> {
+    async fn next(&self, record: &Record) -> Result<Option<Record>> {
         let res = sqlx::query("select * from records where parent = ?1")
             .bind(record.id.clone())
             .map(Self::query_row)
             .fetch_one(&self.pool)
-            .await
-            .ok();
+            .await?;
 
-        res
+        Ok(Some(res))
     }
 
     async fn first(&self, host: &str, tag: &str) -> Result<Record> {

--- a/atuin-client/src/record/sqlite_store.rs
+++ b/atuin-client/src/record/sqlite_store.rs
@@ -2,23 +2,15 @@
 // Multiple stores of multiple types are all stored in one chonky table (for now), and we just index
 // by tag/host
 
-yo tomorrow morning me
-drink that coffee
-then wrap up this interface
-
-you will need to 
-- make sure the records use string IDs
-- add the version in
-- write some tests with a memory sqlite
-
 use std::path::Path;
 use std::str::FromStr;
 
 use async_trait::async_trait;
+use eyre::Result;
 use fs_err as fs;
 use sqlx::{
     sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow},
-    Result, Row,
+    Row,
 };
 
 use atuin_common::record::Record;
@@ -60,11 +52,94 @@ impl SqliteStore {
 
         Ok(())
     }
+
+    async fn save_raw(tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>, r: &Record) -> Result<()> {
+        // In sqlite, we are "limited" to i64. But that is still fine, until 2262.
+        sqlx::query(
+            "insert or ignore into records(id, host, timestamp, tag, version, data)
+                values(?1, ?2, ?3, ?4, ?5, ?6)",
+        )
+        .bind(r.id.as_str())
+        .bind(r.host.as_str())
+        .bind(r.timestamp as i64)
+        .bind(r.tag.as_str())
+        .bind(r.version.as_str())
+        .bind(r.data.as_slice())
+        .execute(tx)
+        .await?;
+
+        Ok(())
+    }
+
+    fn query_row(row: SqliteRow) -> Record {
+        let timestamp: i64 = row.get("timestamp");
+
+        Record {
+            id: row.get("id"),
+            host: row.get("host"),
+            timestamp: timestamp as u64,
+            tag: row.get("tag"),
+            version: row.get("version"),
+            data: row.get("data"),
+        }
+    }
 }
 
 #[async_trait]
 impl Store for SqliteStore {
-    async fn push(record: Record) -> Result<Record> {
+    async fn push(&self, record: Record) -> Result<Record> {
+        // TODO: batch inserts
+        let mut tx = self.pool.begin().await?;
+        Self::save_raw(&mut tx, &record).await?;
+
         Ok(record)
+    }
+
+    async fn get(&self, id: String) -> Result<Record> {
+        let res = sqlx::query("select * from records where id = ?1")
+            .bind(id.as_str())
+            .map(Self::query_row)
+            .fetch_one(&self.pool)
+            .await?;
+
+        Ok(res)
+    }
+
+    async fn len(&self, host: String, tag: String) -> Result<u64> {
+        let res: (i64,) =
+            sqlx::query_as("select count(1) from records where host = ?1 and tag = ?2")
+                .bind(host.as_str())
+                .bind(tag.as_str())
+                .fetch_one(&self.pool)
+                .await?;
+
+        Ok(res.0 as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SqliteStore;
+
+    #[tokio::test]
+    async fn create_db() {
+        let db = SqliteStore::new(":memory:").await;
+
+        assert!(
+            db.is_ok(),
+            "db could not be created, {:?}",
+            db.err().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn push_record() {
+        let db = SqliteStore::new(":memory:").await;
+
+        assert!(
+            db.is_ok(),
+            "db could not be created, {:?}",
+            db.err().unwrap()
+        );
     }
 }

--- a/atuin-client/src/record/sqlite_store.rs
+++ b/atuin-client/src/record/sqlite_store.rs
@@ -1,0 +1,70 @@
+// Here we are using sqlite as a pretty dumb store, and will not be running any complex queries.
+// Multiple stores of multiple types are all stored in one chonky table (for now), and we just index
+// by tag/host
+
+yo tomorrow morning me
+drink that coffee
+then wrap up this interface
+
+you will need to 
+- make sure the records use string IDs
+- add the version in
+- write some tests with a memory sqlite
+
+use std::path::Path;
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use fs_err as fs;
+use sqlx::{
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow},
+    Result, Row,
+};
+
+use atuin_common::record::Record;
+
+use super::store::Store;
+
+pub struct SqliteStore {
+    pool: SqlitePool,
+}
+
+impl SqliteStore {
+    pub async fn new(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+
+        debug!("opening sqlite database at {:?}", path);
+
+        let create = !path.exists();
+        if create {
+            if let Some(dir) = path.parent() {
+                fs::create_dir_all(dir)?;
+            }
+        }
+
+        let opts = SqliteConnectOptions::from_str(path.as_os_str().to_str().unwrap())?
+            .journal_mode(SqliteJournalMode::Wal)
+            .create_if_missing(true);
+
+        let pool = SqlitePoolOptions::new().connect_with(opts).await?;
+
+        Self::setup_db(&pool).await?;
+
+        Ok(Self { pool })
+    }
+
+    async fn setup_db(pool: &SqlitePool) -> Result<()> {
+        debug!("running sqlite database setup");
+
+        sqlx::migrate!("./record-migrations").run(pool).await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Store for SqliteStore {
+    async fn push(record: Record) -> Result<Record> {
+        Ok(record)
+    }
+}

--- a/atuin-client/src/record/sqlite_store.rs
+++ b/atuin-client/src/record/sqlite_store.rs
@@ -106,7 +106,7 @@ impl Store for SqliteStore {
         // If you push in a batch of nothing it does... nothing.
         let mut last: Option<Record> = None;
         for record in records {
-            Self::save_raw(&mut tx, &record).await?;
+            Self::save_raw(&mut tx, record).await?;
 
             last = Some(record.clone());
         }

--- a/atuin-client/src/record/store.rs
+++ b/atuin-client/src/record/store.rs
@@ -12,4 +12,8 @@ pub trait Store {
     async fn push(&self, record: Record) -> Result<Record>;
     async fn get(&self, id: &str) -> Result<Record>;
     async fn len(&self, host: &str, tag: &str) -> Result<u64>;
+
+    // Get the first record for a given host and tag
+    async fn first(&self, host: &str, tag: &str) -> Result<Record>;
+    async fn last(&self, host: &str, tag: &str) -> Result<Record>;
 }

--- a/atuin-client/src/record/store.rs
+++ b/atuin-client/src/record/store.rs
@@ -9,7 +9,7 @@ use atuin_common::record::Record;
 /// be shell history, kvs, etc.
 #[async_trait]
 pub trait Store {
-    async fn push(record: Record) -> Result<Record>;
-    async fn get(id: String) -> Result<Record>;
-    async fn len(host: String, tag: String) -> Result<usize>;
+    async fn push(&self, record: Record) -> Result<Record>;
+    async fn get(&self, id: String) -> Result<Record>;
+    async fn len(&self, host: String, tag: String) -> Result<u64>;
 }

--- a/atuin-client/src/record/store.rs
+++ b/atuin-client/src/record/store.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+use eyre::Result;
+
+use atuin_common::record::Record;
+
+/// A record store stores records
+/// In more detail - we tend to need to process this into _another_ format to actually query it.
+/// As is, the record store is intended as the source of truth for arbitratry data, which could
+/// be shell history, kvs, etc.
+#[async_trait]
+pub trait Store {
+    async fn push(record: Record) -> Result<Record>;
+    async fn get(id: String) -> Result<Record>;
+    async fn len(host: String, tag: String) -> Result<usize>;
+}

--- a/atuin-client/src/record/store.rs
+++ b/atuin-client/src/record/store.rs
@@ -22,7 +22,7 @@ pub trait Store {
     async fn get(&self, id: &str) -> Result<Record>;
     async fn len(&self, host: &str, tag: &str) -> Result<u64>;
 
-    async fn next(&self, record: &Record) -> Option<Record>;
+    async fn next(&self, record: &Record) -> Result<Option<Record>>;
 
     // Get the first record for a given host and tag
     async fn first(&self, host: &str, tag: &str) -> Result<Record>;

--- a/atuin-client/src/record/store.rs
+++ b/atuin-client/src/record/store.rs
@@ -9,22 +9,22 @@ use atuin_common::record::Record;
 /// be shell history, kvs, etc.
 #[async_trait]
 pub trait Store {
-    // Push a record and return it
-    async fn push(&self, record: Record) -> Result<Record>;
+    // Push a record
+    async fn push(&self, record: &Record) -> Result<()> {
+        self.push_batch(std::iter::once(record)).await
+    }
 
     // Push a batch of records, all in one transaction
-    // Returns a record if you push at least one. If the iterator is empty, then
-    // there is no return record.
-    async fn push_batch(
-        &self,
-        records: impl Iterator<Item = &Record> + Send + Sync,
-    ) -> Result<Option<Record>>;
+    async fn push_batch(&self, records: impl Iterator<Item = &Record> + Send + Sync) -> Result<()>;
+
     async fn get(&self, id: &str) -> Result<Record>;
     async fn len(&self, host: &str, tag: &str) -> Result<u64>;
 
+    /// Get the record that follows this record
     async fn next(&self, record: &Record) -> Result<Option<Record>>;
 
-    // Get the first record for a given host and tag
-    async fn first(&self, host: &str, tag: &str) -> Result<Record>;
-    async fn last(&self, host: &str, tag: &str) -> Result<Record>;
+    /// Get the first record for a given host and tag
+    async fn first(&self, host: &str, tag: &str) -> Result<Option<Record>>;
+    /// Get the last record for a given host and tag
+    async fn last(&self, host: &str, tag: &str) -> Result<Option<Record>>;
 }

--- a/atuin-client/src/record/store.rs
+++ b/atuin-client/src/record/store.rs
@@ -9,9 +9,20 @@ use atuin_common::record::Record;
 /// be shell history, kvs, etc.
 #[async_trait]
 pub trait Store {
+    // Push a record and return it
     async fn push(&self, record: Record) -> Result<Record>;
+
+    // Push a batch of records, all in one transaction
+    // Returns a record if you push at least one. If the iterator is empty, then
+    // there is no return record.
+    async fn push_batch(
+        &self,
+        records: impl Iterator<Item = &Record> + Send + Sync,
+    ) -> Result<Option<Record>>;
     async fn get(&self, id: &str) -> Result<Record>;
     async fn len(&self, host: &str, tag: &str) -> Result<u64>;
+
+    async fn next(&self, record: &Record) -> Option<Record>;
 
     // Get the first record for a given host and tag
     async fn first(&self, host: &str, tag: &str) -> Result<Record>;

--- a/atuin-client/src/record/store.rs
+++ b/atuin-client/src/record/store.rs
@@ -10,6 +10,6 @@ use atuin_common::record::Record;
 #[async_trait]
 pub trait Store {
     async fn push(&self, record: Record) -> Result<Record>;
-    async fn get(&self, id: String) -> Result<Record>;
-    async fn len(&self, host: String, tag: String) -> Result<u64>;
+    async fn get(&self, id: &str) -> Result<Record>;
+    async fn len(&self, host: &str, tag: &str) -> Result<u64>;
 }

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -141,6 +141,7 @@ pub struct Settings {
     pub sync_address: String,
     pub sync_frequency: String,
     pub db_path: String,
+    pub record_store_path: String,
     pub key_path: String,
     pub session_path: String,
     pub search_mode: SearchMode,
@@ -337,11 +338,14 @@ impl Settings {
         config_file.push("config.toml");
 
         let db_path = data_dir.join("history.db");
+        let record_store_path = data_dir.join("records.db");
+
         let key_path = data_dir.join("key");
         let session_path = data_dir.join("session");
 
         let mut config_builder = Config::builder()
             .set_default("db_path", db_path.to_str())?
+            .set_default("record_store_path", record_store_path.to_str())?
             .set_default("key_path", key_path.to_str())?
             .set_default("session_path", session_path.to_str())?
             .set_default("dialect", "us")?

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -17,6 +17,7 @@ pub const HISTORY_PAGE_SIZE: i64 = 100;
 pub const LAST_SYNC_FILENAME: &str = "last_sync_time";
 pub const LAST_VERSION_CHECK_FILENAME: &str = "last_version_check_time";
 pub const LATEST_VERSION_FILENAME: &str = "latest_version";
+pub const HOST_ID_FILENAME: &str = "host_id";
 
 #[derive(Clone, Debug, Deserialize, Copy, ValueEnum, PartialEq)]
 pub enum SearchMode {
@@ -224,6 +225,21 @@ impl Settings {
 
     pub fn last_version_check() -> Result<chrono::DateTime<Utc>> {
         Settings::load_time_from_file(LAST_VERSION_CHECK_FILENAME)
+    }
+
+    pub fn host_id() -> Option<String> {
+        let id = Settings::read_from_data_dir(HOST_ID_FILENAME);
+
+        if id.is_some() {
+            return id;
+        }
+
+        let uuid = atuin_common::utils::uuid_v7();
+
+        Settings::save_to_data_dir(HOST_ID_FILENAME, uuid.as_simple().to_string().as_ref())
+            .expect("Could not write host ID to data dir");
+
+        Some(uuid.as_simple().to_string())
     }
 
     pub fn should_sync(&self) -> Result<bool> {

--- a/atuin-common/Cargo.toml
+++ b/atuin-common/Cargo.toml
@@ -16,3 +16,4 @@ chrono = { workspace = true }
 serde = { workspace = true }
 uuid = { workspace = true }
 rand = { workspace = true }
+typed-builder = { workspace = true }

--- a/atuin-common/src/lib.rs
+++ b/atuin-common/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
 
 pub mod api;
+pub mod record;
 pub mod utils;

--- a/atuin-common/src/record.rs
+++ b/atuin-common/src/record.rs
@@ -1,0 +1,15 @@
+/// A single record stored inside of our local database
+pub struct Record {
+    pub id: i64,
+
+    pub host: String,
+
+    pub timestamp: u64,
+
+    /// The type of data we are storing here. It is probably useful to also
+    /// include some sort of version. For example, history.v2
+    pub tag: String,
+
+    /// Some data. This can be anything you wish to store. Use the tag field to know how to handle it.
+    pub data: Vec<u8>,
+}

--- a/atuin-common/src/record.rs
+++ b/atuin-common/src/record.rs
@@ -1,4 +1,5 @@
 /// A single record stored inside of our local database
+#[derive(Debug, Clone, PartialEq)]
 pub struct Record {
     pub id: String,
 
@@ -14,4 +15,20 @@ pub struct Record {
 
     /// Some data. This can be anything you wish to store. Use the tag field to know how to handle it.
     pub data: Vec<u8>,
+}
+
+impl Record {
+    pub fn new(host: String, version: String, tag: String, data: Vec<u8>) -> Record {
+        let id = crate::utils::uuid_v7().as_simple().to_string();
+        let timestamp = chrono::Utc::now();
+
+        Record {
+            id,
+            host,
+            timestamp: timestamp.timestamp_nanos() as u64,
+            version,
+            tag,
+            data,
+        }
+    }
 }

--- a/atuin-common/src/record.rs
+++ b/atuin-common/src/record.rs
@@ -1,9 +1,17 @@
 /// A single record stored inside of our local database
 #[derive(Debug, Clone, PartialEq)]
 pub struct Record {
-    pub id: String,
+    pub id: String, // a unique ID
 
+    // TODO(ellie): Optimize the storage here. We use a bunch of IDs, and currently store
+    // as strings. I would rather avoid normalization, so store as UUID binary instead of
+    // encoding to a string and wasting much more storage.
     pub host: String,
+
+    // A store is technically just a double linked list
+    // We can do some cheating with the timestamps, but should not rely upon them.
+    // Clocks are tricksy.
+    pub parent: Option<String>,
 
     pub timestamp: u64,
 
@@ -18,13 +26,20 @@ pub struct Record {
 }
 
 impl Record {
-    pub fn new(host: String, version: String, tag: String, data: Vec<u8>) -> Record {
+    pub fn new(
+        host: String,
+        version: String,
+        tag: String,
+        parent: Option<String>,
+        data: Vec<u8>,
+    ) -> Record {
         let id = crate::utils::uuid_v7().as_simple().to_string();
         let timestamp = chrono::Utc::now();
 
         Record {
             id,
             host,
+            parent,
             timestamp: timestamp.timestamp_nanos() as u64,
             version,
             tag,

--- a/atuin-common/src/record.rs
+++ b/atuin-common/src/record.rs
@@ -1,5 +1,7 @@
+use serde::{Deserialize, Serialize};
+
 /// A single record stored inside of our local database
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Record {
     pub id: String, // a unique ID
 

--- a/atuin-common/src/record.rs
+++ b/atuin-common/src/record.rs
@@ -1,22 +1,31 @@
 use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
 
 /// A single record stored inside of our local database
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TypedBuilder)]
 pub struct Record {
-    pub id: String, // a unique ID
+    /// a unique ID
+    #[builder(default = crate::utils::uuid_v7().as_simple().to_string())]
+    pub id: String,
 
+    /// The unique ID of the host.
     // TODO(ellie): Optimize the storage here. We use a bunch of IDs, and currently store
     // as strings. I would rather avoid normalization, so store as UUID binary instead of
     // encoding to a string and wasting much more storage.
     pub host: String,
 
+    /// The ID of the parent entry
     // A store is technically just a double linked list
     // We can do some cheating with the timestamps, but should not rely upon them.
     // Clocks are tricksy.
+    #[builder(default)]
     pub parent: Option<String>,
 
+    /// The creation time in nanoseconds since unix epoch
+    #[builder(default = chrono::Utc::now().timestamp_nanos() as u64)]
     pub timestamp: u64,
 
+    /// The version the data in the entry conforms to
     // However we want to track versions for this tag, eg v2
     pub version: String,
 
@@ -28,34 +37,13 @@ pub struct Record {
 }
 
 impl Record {
-    pub fn new(
-        host: String,
-        version: String,
-        tag: String,
-        parent: Option<String>,
-        data: Vec<u8>,
-    ) -> Record {
-        let id = crate::utils::uuid_v7().as_simple().to_string();
-        let timestamp = chrono::Utc::now();
-
-        Record {
-            id,
-            host,
-            parent,
-            timestamp: timestamp.timestamp_nanos() as u64,
-            version,
-            tag,
-            data,
-        }
-    }
-
     pub fn new_child(&self, data: Vec<u8>) -> Record {
-        Self::new(
-            self.host.clone(),
-            self.version.clone(),
-            self.tag.clone(),
-            Some(self.id.clone()),
-            data,
-        )
+        Record::builder()
+            .host(self.host.clone())
+            .version(self.version.clone())
+            .parent(Some(self.id.clone()))
+            .tag(self.tag.clone())
+            .data(data)
+            .build()
     }
 }

--- a/atuin-common/src/record.rs
+++ b/atuin-common/src/record.rs
@@ -46,4 +46,14 @@ impl Record {
             data,
         }
     }
+
+    pub fn new_child(&self, data: Vec<u8>) -> Record {
+        Self::new(
+            self.host.clone(),
+            self.version.clone(),
+            self.tag.clone(),
+            Some(self.id.clone()),
+            data,
+        )
+    }
 }

--- a/atuin-common/src/record.rs
+++ b/atuin-common/src/record.rs
@@ -1,13 +1,15 @@
 /// A single record stored inside of our local database
 pub struct Record {
-    pub id: i64,
+    pub id: String,
 
     pub host: String,
 
     pub timestamp: u64,
 
-    /// The type of data we are storing here. It is probably useful to also
-    /// include some sort of version. For example, history.v2
+    // However we want to track versions for this tag, eg v2
+    pub version: String,
+
+    /// The type of data we are storing here. Eg, "history"
     pub tag: String,
 
     /// Some data. This can be anything you wish to store. Use the tag field to know how to handle it.

--- a/atuin/src/command/client/kv.rs
+++ b/atuin/src/command/client/kv.rs
@@ -35,10 +35,20 @@ impl Cmd {
                 };
 
                 let bytes = record.serialize()?;
+
+                let len = store.len(host_id.as_str(), kv_tag).await?;
+
+                let parent = if len > 0 {
+                    Some(store.last(host_id.as_str(), kv_tag).await?.id)
+                } else {
+                    None
+                };
+
                 let record = atuin_common::record::Record::new(
                     host_id,
                     kv_version.to_string(),
                     kv_tag.to_string(),
+                    parent,
                     bytes,
                 );
 

--- a/atuin/src/command/client/kv.rs
+++ b/atuin/src/command/client/kv.rs
@@ -1,0 +1,53 @@
+use clap::Subcommand;
+use eyre::Result;
+use serde::{Deserialize, Serialize};
+
+use atuin_client::{kv::KvRecord, record::store::Store, settings::Settings};
+
+#[derive(Subcommand)]
+#[command(infer_subcommands = true)]
+pub enum Cmd {
+    // atuin kv set foo bar bar
+    Set {
+        #[arg(long, short)]
+        key: String,
+
+        value: String,
+    },
+
+    // atuin kv get foo => bar baz
+    Get {
+        key: String,
+    },
+}
+
+impl Cmd {
+    pub async fn run(&self, settings: &Settings, store: &mut impl Store) -> Result<()> {
+        let kv_version = "v0";
+        let kv_tag = "kv";
+        let host_id = Settings::host_id().expect("failed to get host_id");
+
+        match self {
+            Self::Set { key, value } => {
+                let record = KvRecord {
+                    key: key.to_string(),
+                    value: value.to_string(),
+                };
+
+                let bytes = record.serialize()?;
+                let record = atuin_common::record::Record::new(
+                    host_id,
+                    kv_version.to_string(),
+                    kv_tag.to_string(),
+                    bytes,
+                );
+
+                store.push(record).await?;
+
+                Ok(())
+            }
+
+            Self::Get { key } => Ok(()),
+        }
+    }
+}

--- a/atuin/src/command/client/kv.rs
+++ b/atuin/src/command/client/kv.rs
@@ -21,7 +21,11 @@ pub enum Cmd {
 }
 
 impl Cmd {
-    pub async fn run(&self, _settings: &Settings, store: &mut impl Store) -> Result<()> {
+    pub async fn run(
+        &self,
+        _settings: &Settings,
+        store: &mut (impl Store + Send + Sync),
+    ) -> Result<()> {
         let kv_store = KvStore::new();
 
         match self {


### PR DESCRIPTION
Super basic PoC, that adds a few things

1. Introduce the concept of a records, and a record store

This stores a linked list of... data. Actually just anything! This data could be shell history, but for now is simple key-values. The idea here is to store it locally in a format that works much better for effective syncing. Note that we store it per host. This is intentional, as when sync works the idea is that machines will write their own local data, but read from all

2. Introduce key value store

This is both a cool feature that we wanted, but also a demo of the sync. Rather than mess with history sync from day 0, we can do it with something lower stakes. 

This is not final. I still need to implement sync, and I still need to "build" the history records into an actual kv store. The idea of a record store is not that live queries will run on it, but that it will act as a source of truth