### PR TITLE
Add support to override hostname and username via env vars

### DIFF
--- a/atuin-client/src/api_client.rs
+++ b/atuin-client/src/api_client.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::env;
 
 use chrono::Utc;
 use eyre::{bail, Result};
@@ -161,10 +162,13 @@ impl<'a> Client<'a> {
         host: Option<String>,
         deleted: HashSet<String>,
     ) -> Result<Vec<History>> {
-        let host = match host {
-            None => hash_str(&format!("{}:{}", whoami::hostname(), whoami::username())),
-            Some(h) => h,
-        };
+        let host = host.unwrap_or_else(|| {
+            hash_str(&format!(
+                "{}:{}",
+                env::var("ATUIN_HOST_NAME").unwrap_or_else(|_| whoami::hostname()),
+                env::var("ATUIN_HOST_USER").unwrap_or_else(|_| whoami::username())
+            ))
+        });
 
         let url = format!(
             "{}/sync/history?sync_ts={}&history_ts={}&host={}",

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -43,7 +43,11 @@ pub fn current_context() -> Context {
         eprintln!("ERROR: Failed to find $ATUIN_SESSION in the environment. Check that you have correctly set up your shell.");
         std::process::exit(1);
     };
-    let hostname = format!("{}:{}", whoami::hostname(), whoami::username());
+    let hostname = format!(
+        "{}:{}",
+        env::var("ATUIN_HOST_NAME").unwrap_or_else(|_| whoami::hostname()),
+        env::var("ATUIN_HOST_USER").unwrap_or_else(|_| whoami::username())
+    );
     let cwd = utils::get_current_dir();
 
     Context {

--- a/atuin-client/src/history.rs
+++ b/atuin-client/src/history.rs
@@ -49,8 +49,13 @@ impl History {
         let session = session
             .or_else(|| env::var("ATUIN_SESSION").ok())
             .unwrap_or_else(|| uuid_v7().as_simple().to_string());
-        let hostname =
-            hostname.unwrap_or_else(|| format!("{}:{}", whoami::hostname(), whoami::username()));
+        let hostname = hostname.unwrap_or_else(|| {
+            format!(
+                "{}:{}",
+                env::var("ATUIN_HOST_NAME").unwrap_or_else(|_| whoami::hostname()),
+                env::var("ATUIN_HOST_USER").unwrap_or_else(|_| whoami::username())
+            )
+        });
 
         Self {
             id: uuid_v7().as_simple().to_string(),


### PR DESCRIPTION
This PR allows you to set `ATUIN_HOST_NAME` and `ATUIN_HOST_USER` as a means of overriding the default values from the system calls. I found that controlling the hostname and user when using devcontainers in a container was extremely tedious and this will help a great deal in controlling how things are persisted in atuin.

I chose the names  `ATUIN_HOST_NAME` and `ATUIN_HOST_USER` to try to avoid confusion with a user's atuin username, but if anyone has any recommendations I'd be more than happy to change them.