### PR TITLE
remove rmp-serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,6 @@ dependencies = [
  "regex",
  "reqwest",
  "rmp",
- "rmp-serde",
  "semver",
  "serde",
  "serde_json",
@@ -1756,17 +1755,6 @@ dependencies = [
  "byteorder",
  "num-traits",
  "paste",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
 ]
 
 [[package]]

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -51,7 +51,6 @@ sql-builder = "3"
 lazy_static = "1"
 memchr = "2.5"
 rmp = { version = "0.8.11" }
-rmp-serde = { version = "1.1.1" }
 typed-builder = "0.14.0"
 
 # sync


### PR DESCRIPTION
Messagepack is a nice serialisation format, but rmp-serde is not. serde is designed for self describing documents. Messagepack is not self describing, which makes it prone to breakages.

Common breakages include:
* reordering fields
* adding fields
* removing fields

By writing the encoding out explicitly, we can see clearer when the encode/decode change will cause a breakage. The record version is used to allow different encodings.