### PR TITLE
Fix `nu` section in `key-bindings.md` - `set-env` -> `let-env`

### DIFF
--- a/docs/docs/key-binding.md
+++ b/docs/docs/key-binding.md
@@ -73,7 +73,7 @@ bind -M insert \cr _atuin_search
 # nu
 
 ```
-set-env ATUIN_NOBIND = true
+let-env ATUIN_NOBIND = true
 atuin init nu | save -f ~/.local/share/atuin/init.nu #make sure you created the directory beforehand with `mkdir ~/.local/share/atuin/init.nu`
 source ~/.local/share/atuin/init.nu
 


### PR DESCRIPTION
I don't think `set-env` exists 🤔 

```
❯ : set-env ATUIN_NOBIND = true
Error: nu::shell::external_command

  × External command failed
   ╭─[entry #6:1:1]
 1 │ set-env ATUIN_NOBIND = true
   · ───┬───
   ·    ╰── did you mean 'let-env'?
   ╰────
  help: No such file or directory (os error 2)
```