### PR TITLE
Update Nushell support to use supported $env update syntax

### DIFF
--- a/atuin/src/command/init.rs
+++ b/atuin/src/command/init.rs
@@ -98,7 +98,7 @@ bind -M insert \e\[A _atuin_bind_up";
         println!("{full}");
 
         if std::env::var("ATUIN_NOBIND").is_err() {
-            const BIND_CTRL_R: &str = r#"let-env config = (
+            const BIND_CTRL_R: &str = r#"$env.config = (
     $env.config | upsert keybindings (
         $env.config.keybindings
         | append {
@@ -111,7 +111,7 @@ bind -M insert \e\[A _atuin_bind_up";
     )
 )
 "#;
-            const BIND_UP_ARROW: &str = r#"let-env config = (
+            const BIND_UP_ARROW: &str = r#"$env.config = (
     $env.config | upsert keybindings (
         $env.config.keybindings
         | append {

--- a/atuin/src/shell/atuin.nu
+++ b/atuin/src/shell/atuin.nu
@@ -1,5 +1,5 @@
 # Source this in your ~/.config/nushell/config.nu
-let-env ATUIN_SESSION = (atuin uuid)
+$env.ATUIN_SESSION = (atuin uuid)
 
 # Magic token to make sure we don't record commands run by keybindings
 let ATUIN_KEYBINDING_TOKEN = $"# (random uuid)"
@@ -10,7 +10,7 @@ let _atuin_pre_execution = {||
         return
     }
     if not ($cmd | str starts-with $ATUIN_KEYBINDING_TOKEN) {
-        let-env ATUIN_HISTORY_ID = (atuin history start -- $cmd)
+        $env.ATUIN_HISTORY_ID = (atuin history start -- $cmd)
     }
 }
 
@@ -35,7 +35,7 @@ def _atuin_search_cmd [...flags: string] {
     ] | str join "\n"
 }
 
-let-env config = (
+$env.config = (
     $env.config | upsert hooks (
         $env.config.hooks
         | upsert pre_execution ($env.config.hooks.pre_execution | append $_atuin_pre_execution)

--- a/docs/docs/key-binding.md
+++ b/docs/docs/key-binding.md
@@ -87,12 +87,12 @@ bind -M insert \cr _atuin_search
 ## nu
 
 ```
-let-env ATUIN_NOBIND = true
+$env.ATUIN_NOBIND = true
 atuin init nu | save -f ~/.local/share/atuin/init.nu #make sure you created the directory beforehand with `mkdir ~/.local/share/atuin/init.nu`
 source ~/.local/share/atuin/init.nu
 
 #bind to ctrl-r in emacs, vi_normal and vi_insert modes, add any other bindings you want here too
-let-env config = (
+$env.config = (
     $env.config | upsert keybindings (
         $env.config.keybindings
         | append {


### PR DESCRIPTION
Greetings!

The Nushell team is working on removing `let-env FOO = ...` and moving code to use `$env.FOO = ...` as it's more honest about what's happening (rather than being scoped like a `let`). This PR should move atuin to use the supported syntax (assuming I didn't miss anything 😅).