### PR TITLE
fix key encodings again

### DIFF
--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-client"
-edition = "2018"
+edition = "2021"
 description = "client library for atuin"
 
 version = { workspace = true }


### PR DESCRIPTION
I should have spotted this when I got rid of rmp-serde, but I missed it. The original `rmp_serde::to_vec(key.as_slice())` code didn't convert to `write_bin`, but rather [`write_array_len`](https://github.com/3Hren/msgpack-rust/blob/f4ad0d0257edfea460eb176cdb7d11ddfe97ba3b/rmp-serde/src/encode.rs#L615) and multiple [`write_uint` calls](https://github.com/3Hren/msgpack-rust/blob/f4ad0d0257edfea460eb176cdb7d11ddfe97ba3b/rmp-serde/src/encode.rs#L522-L537).

Thankfully this hasn't made it into a release yet, and in my testing, the incorrect code just wouldn't parse the key, rather than encrypting anything bogus. No harm done.

I never want to use a hidden encoding scheme ever again.