### PR TITLE
use some fancy types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "directories",
  "eyre",
  "fs-err",
+ "futures",
  "generic-array",
  "hex",
  "interim",
@@ -183,6 +184,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.8.5",
  "serde",
+ "sqlx",
  "typed-builder",
  "uuid",
 ]
@@ -953,6 +955,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
 
 [[package]]
+name = "futures"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1008,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
 name = "futures-macro"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,10 +1042,13 @@ version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -54,6 +54,7 @@ rmp = { version = "0.8.11" }
 typed-builder = "0.14.0"
 tokio = { workspace = true }
 semver = { workspace = true }
+futures = "0.3"
 
 # encryption
 rusty_paseto = { version = "0.5.0", default-features = false }

--- a/atuin-client/src/api_client.rs
+++ b/atuin-client/src/api_client.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::env;
-use uuid::Uuid;
 
 use chrono::Utc;
 use eyre::{bail, Result};
@@ -9,7 +8,7 @@ use reqwest::{
     StatusCode, Url,
 };
 
-use atuin_common::record::{EncryptedData, Record};
+use atuin_common::record::{EncryptedData, HostId, Record, RecordId};
 use atuin_common::{
     api::{
         AddHistoryRequest, CountResponse, DeleteHistoryRequest, ErrorResponse, IndexResponse,
@@ -211,20 +210,24 @@ impl<'a> Client<'a> {
 
     pub async fn next_records(
         &self,
-        host: Uuid,
+        host: HostId,
         tag: String,
-        start: Option<Uuid>,
+        start: Option<RecordId>,
         count: u64,
     ) -> Result<Vec<Record<EncryptedData>>> {
         let url = format!(
             "{}/record/next?host={}&tag={}&count={}",
-            self.sync_addr, host, tag, count
+            self.sync_addr, host.0, tag, count
         );
         let mut url = Url::parse(url.as_str())?;
 
         if let Some(start) = start {
             url.set_query(Some(
-                format!("host={}&tag={}&count={}&start={}", host, tag, count, start).as_str(),
+                format!(
+                    "host={}&tag={}&count={}&start={}",
+                    host.0, tag, count, start.0
+                )
+                .as_str(),
             ));
         }
 

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -14,7 +14,6 @@ use sqlx::{
     Result, Row,
 };
 
-
 use super::{
     history::History,
     ordering,
@@ -58,7 +57,7 @@ pub fn current_context() -> Context {
         session,
         hostname,
         cwd,
-        host_id: host_id.as_simple().to_string(),
+        host_id: host_id.0.as_simple().to_string(),
     }
 }
 

--- a/atuin-client/src/record/store.rs
+++ b/atuin-client/src/record/store.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
 use eyre::Result;
 
-use atuin_common::record::{EncryptedData, Record};
-use uuid::Uuid;
+use atuin_common::record::{EncryptedData, HostId, Record, RecordId, RecordIndex};
 
 /// A record store stores records
 /// In more detail - we tend to need to process this into _another_ format to actually query it.
@@ -21,22 +20,22 @@ pub trait Store {
         records: impl Iterator<Item = &Record<EncryptedData>> + Send + Sync,
     ) -> Result<()>;
 
-    async fn get(&self, id: Uuid) -> Result<Record<EncryptedData>>;
-    async fn len(&self, host: Uuid, tag: &str) -> Result<u64>;
+    async fn get(&self, id: RecordId) -> Result<Record<EncryptedData>>;
+    async fn len(&self, host: HostId, tag: &str) -> Result<u64>;
 
     /// Get the record that follows this record
     async fn next(&self, record: &Record<EncryptedData>) -> Result<Option<Record<EncryptedData>>>;
 
     /// Get the first record for a given host and tag
-    async fn head(&self, host: Uuid, tag: &str) -> Result<Option<Record<EncryptedData>>>;
+    async fn head(&self, host: HostId, tag: &str) -> Result<Option<Record<EncryptedData>>>;
 
     /// Get the last record for a given host and tag
-    async fn tail(&self, host: Uuid, tag: &str) -> Result<Option<Record<EncryptedData>>>;
+    async fn tail(&self, host: HostId, tag: &str) -> Result<Option<Record<EncryptedData>>>;
 
     // Get the last record for all hosts for a given tag, useful for the read path of apps.
     async fn tag_tails(&self, tag: &str) -> Result<Vec<Record<EncryptedData>>>;
 
     // Get the latest host/tag/record tuple for every set in the store. useful for building an
     // index
-    async fn tail_records(&self) -> Result<Vec<(Uuid, String, Uuid)>>;
+    async fn tail_records(&self) -> Result<RecordIndex>;
 }

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -4,6 +4,7 @@ use std::{
     str::FromStr,
 };
 
+use atuin_common::record::HostId;
 use chrono::{prelude::*, Utc};
 use clap::ValueEnum;
 use config::{Config, Environment, File as ConfigFile, FileFormat};
@@ -230,13 +231,13 @@ impl Settings {
         Settings::load_time_from_file(LAST_VERSION_CHECK_FILENAME)
     }
 
-    pub fn host_id() -> Option<Uuid> {
+    pub fn host_id() -> Option<HostId> {
         let id = Settings::read_from_data_dir(HOST_ID_FILENAME);
 
         if let Some(id) = id {
             let parsed =
                 Uuid::from_str(id.as_str()).expect("failed to parse host ID from local directory");
-            return Some(parsed);
+            return Some(HostId(parsed));
         }
 
         let uuid = atuin_common::utils::uuid_v7();
@@ -244,7 +245,7 @@ impl Settings {
         Settings::save_to_data_dir(HOST_ID_FILENAME, uuid.as_simple().to_string().as_ref())
             .expect("Could not write host ID to data dir");
 
-        Some(uuid)
+        Some(HostId(uuid))
     }
 
     pub fn should_sync(&self) -> Result<bool> {

--- a/atuin-common/Cargo.toml
+++ b/atuin-common/Cargo.toml
@@ -18,6 +18,7 @@ uuid = { workspace = true }
 rand = { workspace = true }
 typed-builder = { workspace = true }
 eyre = { workspace = true }
+sqlx = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/atuin-common/src/lib.rs
+++ b/atuin-common/src/lib.rs
@@ -3,18 +3,8 @@
 /// Defines a new UUID type wrapper
 macro_rules! new_uuid {
     ($name:ident) => {
-        #[derive(
-            Debug,
-            Copy,
-            Clone,
-            PartialEq,
-            Eq,
-            Hash,
-            PartialOrd,
-            Ord,
-            serde::Serialize,
-            serde::Deserialize,
-        )]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        #[derive(serde::Serialize, serde::Deserialize)]
         #[serde(transparent)]
         pub struct $name(pub Uuid);
 

--- a/atuin-common/src/lib.rs
+++ b/atuin-common/src/lib.rs
@@ -1,5 +1,57 @@
 #![forbid(unsafe_code)]
 
+/// Defines a new UUID type wrapper
+macro_rules! new_uuid {
+    ($name:ident) => {
+        #[derive(
+            Debug,
+            Copy,
+            Clone,
+            PartialEq,
+            Eq,
+            Hash,
+            PartialOrd,
+            Ord,
+            serde::Serialize,
+            serde::Deserialize,
+        )]
+        #[serde(transparent)]
+        pub struct $name(pub Uuid);
+
+        impl<DB: sqlx::Database> sqlx::Type<DB> for $name
+        where
+            Uuid: sqlx::Type<DB>,
+        {
+            fn type_info() -> <DB as sqlx::Database>::TypeInfo {
+                Uuid::type_info()
+            }
+        }
+
+        impl<'r, DB: sqlx::Database> sqlx::Decode<'r, DB> for $name
+        where
+            Uuid: sqlx::Decode<'r, DB>,
+        {
+            fn decode(
+                value: <DB as sqlx::database::HasValueRef<'r>>::ValueRef,
+            ) -> std::result::Result<Self, sqlx::error::BoxDynError> {
+                Uuid::decode(value).map(Self)
+            }
+        }
+
+        impl<'q, DB: sqlx::Database> sqlx::Encode<'q, DB> for $name
+        where
+            Uuid: sqlx::Encode<'q, DB>,
+        {
+            fn encode_by_ref(
+                &self,
+                buf: &mut <DB as sqlx::database::HasArguments<'q>>::ArgumentBuffer,
+            ) -> sqlx::encode::IsNull {
+                self.0.encode_by_ref(buf)
+            }
+        }
+    };
+}
+
 pub mod api;
 pub mod record;
 pub mod utils;

--- a/atuin-server-database/src/lib.rs
+++ b/atuin-server-database/src/lib.rs
@@ -14,14 +14,13 @@ use self::{
 };
 use async_trait::async_trait;
 use atuin_common::{
-    record::{EncryptedData, Record},
+    record::{EncryptedData, HostId, Record, RecordId, RecordIndex},
     utils::get_days_from_month,
 };
 use chrono::{Datelike, TimeZone};
 use chronoutil::RelativeDuration;
 use serde::{de::DeserializeOwned, Serialize};
 use tracing::instrument;
-use uuid::Uuid;
 
 #[derive(Debug)]
 pub enum DbError {
@@ -63,14 +62,14 @@ pub trait Database: Sized + Clone + Send + Sync + 'static {
     async fn next_records(
         &self,
         user: &User,
-        host: Uuid,
+        host: HostId,
         tag: String,
-        start: Option<Uuid>,
+        start: Option<RecordId>,
         count: u64,
     ) -> DbResult<Vec<Record<EncryptedData>>>;
 
     // Return the tail record ID for each store, so (HostID, Tag, TailRecordID)
-    async fn tail_records(&self, user: &User) -> DbResult<Vec<(Uuid, String, Uuid)>>;
+    async fn tail_records(&self, user: &User) -> DbResult<RecordIndex>;
 
     async fn count_history_range(
         &self,


### PR DESCRIPTION
sorry @ellie. i'm sure this will cause conflicts for your local changes 😓 

TL;DR

Creates a RecordId and a HostId type wrapper. Reduces potential for confusion of IDs.

Also: implement the Extend trait for RecordIndex and collect the database results directly into them