### PR TITLE
Disable server tests in the nix build

### DIFF
--- a/atuin.nix
+++ b/atuin.nix
@@ -35,6 +35,12 @@ rustPlatform.buildRustPackage {
       --zsh <($out/bin/atuin gen-completions -s zsh)
   '';
 
+  # Additional flags passed to the cargo test binary, see `cargo test -- --help`
+  checkFlags = [
+    # Registration tests require a postgres server
+    "--skip=registration"
+  ];
+
   meta = with lib; {
     description = "Replacement for a shell history which records additional commands context with optional encrypted synchronization between machines";
     homepage = "https://github.com/ellie/atuin";

--- a/flake.lock
+++ b/flake.lock
@@ -17,12 +17,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -33,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677560409,
-        "narHash": "sha256-PIvUIsVNozPXe1FmNe9c6B8Febl3t9+51uBKMJ1Q8o0=",
+        "lastModified": 1690441914,
+        "narHash": "sha256-Ac+kJQ5z9MDAMyzSc0i0zJDx2i3qi9NjlW5Lz285G/I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e56d6ec92c8fb4192f1392aa5c4101ad77f2070",
+        "rev": "db8672b8d0a2593c2405aed0c1dfa64b2a2f428f",
         "type": "github"
       },
       "original": {
@@ -52,6 +55,21 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },


### PR DESCRIPTION
The recent #1096 broke the Nix CI, this change fixes the nix build by disabling those tests. New tests that also use the postgres server will need to be excluded as well using additional '--skip' options or by keeping them all in the same excluded module. Adding a postgres server to make these pass is _technically_ possible, but probably not worth the maintenance burden for you.

For background, the `nix build` step runs the tests by default in an attempt to verify the correctness of the build. These tests are run in a sandbox with no network access, so it's fairly common that projects with complex test cases just won't work within it very easily.

Alternately we could just disable tests entirely in the nix build by using `doCheck = false;` instead of `checkFlags`. [See docs for guidance](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#disabling-package-tests-disabling-package-tests). That may be preferable if you don't expect to get any value out of running the tests inside the nix sandbox.

(I noticed this because I do actually use the nix flake to run a bleeding edge version of the client on my own systems, so this flow is tested by at least 1 person :))